### PR TITLE
Remove focused window index from Layout basic parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.5.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.5.1 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/layouts/Grid.cpp
+++ b/src/layouts/Grid.cpp
@@ -5,11 +5,8 @@ namespace ymwm::layouts {
   template <>
   void Layout::apply(const GridParameters& parameters,
                      window::Window& w) noexcept {
-    auto& [screen_width,
-           screen_height,
-           screen_margins,
-           focused_window_index,
-           number_of_windows] = basic_parameters;
+    auto& [screen_width, screen_height, screen_margins, number_of_windows] =
+        basic_parameters;
 
     auto& [margins, grid_size, number_of_margins] = parameters;
 

--- a/src/layouts/Layout.h
+++ b/src/layouts/Layout.h
@@ -15,7 +15,6 @@ namespace ymwm::layouts {
       int screen_width;
       int screen_height;
       config::layouts::Margin screen_margins;
-      std::size_t focused_window_index;
       std::size_t number_of_windows;
     } basic_parameters;
 

--- a/src/layouts/Maximized.cpp
+++ b/src/layouts/Maximized.cpp
@@ -6,11 +6,8 @@ namespace ymwm::layouts {
   template <>
   void Layout::apply(const MaximisedParameters& parameters,
                      window::Window& w) noexcept {
-    auto& [screen_width,
-           screen_height,
-           screen_margins,
-           focused_window_index,
-           number_of_windows] = basic_parameters;
+    auto& [screen_width, screen_height, screen_margins, number_of_windows] =
+        basic_parameters;
 
     w.w = screen_width - screen_margins.left - screen_margins.right -
           (2 * w.border_width);

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -38,7 +38,6 @@ namespace ymwm::window {
 
       m_basic_layout_parameters.screen_width = screen_width;
       m_basic_layout_parameters.screen_height = screen_height;
-      m_basic_layout_parameters.focused_window_index = 0ul;
       m_basic_layout_parameters.number_of_windows = m_windows.size();
 
       auto layout =

--- a/tests/layouts/LayoutsTest.cpp
+++ b/tests/layouts/LayoutsTest.cpp
@@ -111,7 +111,6 @@ TEST(TestLayouts, GridLayout) {
   basic_parameters.screen_margins.top = 0u;
   basic_parameters.screen_margins.bottom = 0u;
   basic_parameters.number_of_windows = 4ul;
-  basic_parameters.focused_window_index = 0ul;
 
   std::vector<ymwm::window::Window> test_windows(
       4,
@@ -180,7 +179,6 @@ TEST(TestLayouts, GridLayout_WithScreenMargins) {
   basic_parameters.screen_margins.top = 5u;
   basic_parameters.screen_margins.bottom = 5u;
   basic_parameters.number_of_windows = 4ul;
-  basic_parameters.focused_window_index = 0ul;
 
   std::vector<ymwm::window::Window> test_windows(
       4,
@@ -249,7 +247,6 @@ TEST(TestLayouts, GridLayout_WithScreenMargins_AndGridMargins) {
   basic_parameters.screen_margins.top = 5u;
   basic_parameters.screen_margins.bottom = 5u;
   basic_parameters.number_of_windows = 4ul;
-  basic_parameters.focused_window_index = 0ul;
 
   std::vector<ymwm::window::Window> test_windows(
       4,


### PR DESCRIPTION
This PR removes `focused_window_index` from Layout basic parameters as it won't be affecting further implementation of stack layouts.

Changes made:
- Removed `focused_window_index` from Layout parameters and tests