### PR TITLE
Automate command names registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.5.1 LANGUAGES CXX)
+project(WindowManager VERSION 0.6.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/common/Color.cpp
+++ b/src/common/Color.cpp
@@ -4,6 +4,11 @@
 
 namespace ymwm::common {
 
+  Color::Color() noexcept
+      : red(0x0)
+      , green(0x0)
+      , blue(0x0) {}
+
   Color::Color(unsigned short r, unsigned short g, unsigned short b) noexcept
       : red(r)
       , green(g)

--- a/src/common/Color.h
+++ b/src/common/Color.h
@@ -9,6 +9,7 @@ namespace ymwm::common {
     unsigned short green;
     unsigned short blue;
 
+    Color() noexcept;
     Color(unsigned short r, unsigned short g, unsigned short b) noexcept;
     Color(unsigned long color) noexcept;
     Color(const std::string_view color) noexcept;

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "CommandMacro.h"
 #include "common/Color.h"
 
-#include <string_view>
 #include <variant>
 
 namespace ymwm::environment {
@@ -10,54 +10,15 @@ namespace ymwm::environment {
 }
 
 namespace ymwm::environment::commands {
-  struct ExitRequested {
-    static inline constexpr std::string_view type{ "ExitRequested" };
-    void execute([[maybe_unused]] Environment&) const;
-  };
-
-  struct RunTerminal {
-    static inline constexpr std::string_view type{ "RunTerminal" };
-    void execute([[maybe_unused]] Environment&) const;
-  };
-
-  struct ChangeBorderColor {
-    static inline constexpr std::string_view type{ "ChangeBorderColor" };
-    void execute([[maybe_unused]] Environment&) const;
-    common::Color color;
-  };
-
-  struct MoveWindowRight {
-    static inline constexpr std::string_view type{ "MoveWindowRight" };
-    void execute([[maybe_unused]] Environment&) const;
-    int dx;
-  };
-
-  struct CloseWindow {
-    static inline constexpr std::string_view type{ "CloseWindow" };
-    void execute([[maybe_unused]] Environment&) const;
-  };
-
-  struct FocusNextWindow {
-    static inline constexpr std::string_view type{ "FocusNextWindow" };
-    void execute([[maybe_unused]] Environment&) const;
-  };
-
-  struct FocusPrevWindow {
-    static inline constexpr std::string_view type{ "FocusPrevWindow" };
-    void execute([[maybe_unused]] Environment&) const;
-  };
-
-  struct MoveFocusedWindowForward {
-    static inline constexpr std::string_view type{ "MoveFocusedWindowForward" };
-    void execute([[maybe_unused]] Environment&) const;
-  };
-
-  struct MoveFocusedWindowBackward {
-    static inline constexpr std::string_view type{
-      "MoveFocusedWindowBackward"
-    };
-    void execute([[maybe_unused]] Environment&) const;
-  };
+  DEFINE_COMMAND(ExitRequested)
+  DEFINE_COMMAND(RunTerminal)
+  DEFINE_COMMAND_WITH_PARAMS_1(ChangeBorderColor, common::Color color);
+  DEFINE_COMMAND_WITH_PARAMS_1(MoveWindowRight, int dx);
+  DEFINE_COMMAND(CloseWindow)
+  DEFINE_COMMAND(FocusNextWindow)
+  DEFINE_COMMAND(FocusPrevWindow)
+  DEFINE_COMMAND(MoveFocusedWindowForward)
+  DEFINE_COMMAND(MoveFocusedWindowBackward)
 
   using Command = std::variant<ExitRequested,
                                RunTerminal,

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -3,6 +3,7 @@
 #include "CommandMacro.h"
 #include "common/Color.h"
 
+#include <optional>
 #include <variant>
 
 namespace ymwm::environment {
@@ -29,4 +30,26 @@ namespace ymwm::environment::commands {
                                FocusPrevWindow,
                                MoveFocusedWindowForward,
                                MoveFocusedWindowBackward>;
+
+  template <std::size_t Index =
+                std::variant_size_v<environment::commands::Command> - 1ul>
+  static inline std::optional<environment::commands::Command>
+  try_find_command(std::string_view command_type) noexcept {
+    if constexpr (0ul <= Index) {
+      using CommandType =
+          std::variant_alternative_t<Index, environment::commands::Command>;
+      if (command_type == CommandType::type) {
+        return CommandType{};
+      }
+
+      if constexpr (0ul == Index) {
+        return std::nullopt;
+      } else {
+        return try_find_command<Index - 1ul>(command_type);
+      }
+
+    } else {
+      return std::nullopt;
+    }
+  }
 } // namespace ymwm::environment::commands

--- a/src/environment/CommandMacro.h
+++ b/src/environment/CommandMacro.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <string_view>
+
+#define DEFINE_MEMBER(x) x;
+
+#define START_DEFINE_COMMAND(name)                                             \
+  struct name {                                                                \
+    static inline constexpr std::string_view type{ #name };                    \
+    void execute([[maybe_unused]] Environment&) const;
+
+// clang-format off
+#define END_DEFINE_COMMAND };
+// clang-format on
+
+#define DEFINE_COMMAND(name)                                                   \
+  START_DEFINE_COMMAND(name)                                                   \
+  END_DEFINE_COMMAND
+
+#define DEFINE_COMMAND_WITH_PARAMS_1(name, member)                             \
+  START_DEFINE_COMMAND(name)                                                   \
+  DEFINE_MEMBER(member)                                                        \
+  END_DEFINE_COMMAND
+
+#define DEFINE_COMMAND_WITH_PARAMS_2(name, member1, member2)                   \
+  START_DEFINE_COMMAND(name)                                                   \
+  DEFINE_MEMBER(member1)                                                       \
+  DEFINE_MEMBER(member2)                                                       \
+  END_DEFINE_COMMAND
+
+#define DEFINE_COMMAND_WITH_PARAMS_3(name, member1, member2, member3)          \
+  START_DEFINE_COMMAND(name)                                                   \
+  DEFINE_MEMBER(member1)                                                       \
+  DEFINE_MEMBER(member2)                                                       \
+  DEFINE_MEMBER(member3)                                                       \
+  END_DEFINE_COMMAND

--- a/src/events/CMakeLists.txt
+++ b/src/events/CMakeLists.txt
@@ -20,7 +20,9 @@ target_include_directories(events PRIVATE
 )
 target_link_libraries(events PRIVATE
 	${SHARED_LIBS}
+	common
 )
 add_dependencies(events
 	yaml_cpp
+	common
 )

--- a/src/events/utils.h
+++ b/src/events/utils.h
@@ -24,17 +24,7 @@ namespace ymwm::events::utils {
 
   static inline std::optional<environment::commands::Command>
   command_from_type(std::string&& command_type) noexcept {
-    static const std::unordered_map<std::string_view,
-                                    environment::commands::Command>
-        type_to_cmd_table{
-          {   environment::commands::RunTerminal::type,
-           environment::commands::RunTerminal{}  },
-          { environment::commands::ExitRequested::type,
-           environment::commands::ExitRequested{} }
-    };
-    return type_to_cmd_table.contains(command_type)
-               ? std::optional(type_to_cmd_table.at(command_type))
-               : std::nullopt;
+    return environment::commands::try_find_command(command_type);
   }
 
   static inline unsigned int

--- a/tests/events/CMakeLists.txt
+++ b/tests/events/CMakeLists.txt
@@ -10,10 +10,12 @@ target_include_directories(EventsTest
 target_link_libraries(EventsTest
 	${GTEST_LIBRARIES}
 	events
+	common
 )
 add_dependencies(EventsTest
 	googletestlib
 	events
+	common
 )
 add_test(NAME EventsTest COMMAND EventsTest WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/key-bindings.yaml DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)


### PR DESCRIPTION
This PR implements automated way of providing lookup and constructing Command by name, provided with user config.
Previously Command construction was hard-coded to static hash map, holding specific Command name to it's type wrapped in std::variant. This PR reduces the amount of boiler plate code by:
1. Using macro to describe the specific Command type including its string identification.
2. Using `std::variant_alternative_t<Command>::type` to match it with the name provided in user configuration, thus eliminating the need of extra static memory which is needed only temporary during event map creation.