### PR TITLE
Refactor focus management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.7.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.8.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -28,11 +28,11 @@ namespace ymwm::environment::commands {
   }
 
   void FocusNextWindow::execute(Environment& e) const {
-    e.manager().focus_next_window();
+    e.manager().focus().next_window();
   }
 
   void FocusPrevWindow::execute(Environment& e) const {
-    e.manager().focus_prev_window();
+    e.manager().focus().prev_window();
   }
 
   void MoveFocusedWindowForward::execute(Environment& e) const {

--- a/src/window/FocusManager.h
+++ b/src/window/FocusManager.h
@@ -25,7 +25,7 @@ namespace ymwm::window {
       return m_focused_window_index;
     }
 
-    inline void update() const noexcept {
+    inline void update() noexcept {
       if (auto fw = window()) {
         m_env->focus_window(fw->get());
         return;
@@ -34,17 +34,13 @@ namespace ymwm::window {
       m_env->reset_focus();
     }
 
-    inline void update_index() noexcept {
-      if (m_focused_window_index >= m_windows.size() and
-          not m_windows.empty()) {
-        m_focused_window_index = m_windows.size() - 1ul;
-      }
-    }
-
     inline void last_window() noexcept {
       if (m_windows.empty()) {
         return;
       }
+
+      update_index();
+
       m_before_focus_move();
 
       m_focused_window_index = m_windows.size() - 1ul;
@@ -64,6 +60,8 @@ namespace ymwm::window {
         m_env->reset_focus();
         return;
       }
+      update_index();
+
       m_before_focus_move();
 
       m_focused_window_index =
@@ -80,6 +78,8 @@ namespace ymwm::window {
         m_env->reset_focus();
         return;
       }
+
+      update_index();
 
       m_before_focus_move();
 
@@ -98,6 +98,14 @@ namespace ymwm::window {
 
     inline bool is_first_window() const noexcept {
       return not m_windows.empty() and m_focused_window_index == 0ul;
+    }
+
+  private:
+    inline void update_index() noexcept {
+      if (m_focused_window_index >= m_windows.size() and
+          not m_windows.empty()) {
+        m_focused_window_index = m_windows.size() - 1ul;
+      }
     }
 
   private:

--- a/src/window/Manager.h
+++ b/src/window/Manager.h
@@ -18,7 +18,16 @@ namespace ymwm::window {
 
     Manager(Environment* env)
         : m_env(env)
-        , m_focus_manager(m_windows, env)
+        , m_focus_manager(m_windows,
+                          env,
+                          std::bind(&Manager::update_focused_window_border,
+                                    this,
+                                    config::windows::regular_border_width,
+                                    config::windows::regular_border_color),
+                          std::bind(&Manager::update_focused_window_border,
+                                    this,
+                                    config::windows::focused_border_width,
+                                    config::windows::focused_border_color))
         , m_layout_manager(m_windows, env) {
       m_windows.reserve(5);
     }
@@ -32,8 +41,7 @@ namespace ymwm::window {
                                w.w,
                                reinterpret_cast<const char*>(w.name.data()));
       m_windows.push_back(w);
-      m_env->update_window_border(w);
-      focus_last_window();
+      focus().last_window();
       layout().update();
     }
 
@@ -44,7 +52,7 @@ namespace ymwm::window {
       if (erased_successfully) {
         std::cout << std::format("Erased {} \n", id);
         focus().update_index();
-        focus_prev_window();
+        focus().prev_window();
         layout().update();
       }
     }
@@ -59,7 +67,7 @@ namespace ymwm::window {
       if (auto fw = focus().window()) {
         fw->get().border_color = color;
         fw->get().border_width = width;
-        m_env->update_window(fw->get());
+        m_env->update_window_border(fw->get());
       }
     }
 
@@ -80,7 +88,7 @@ namespace ymwm::window {
                     m_windows.at(focus().window_index() + 1ul));
         }
         layout().update();
-        focus_next_window();
+        focus().next_window();
       }
     }
 
@@ -93,7 +101,7 @@ namespace ymwm::window {
                     m_windows.at(focus().window_index() - 1ul));
         }
         layout().update();
-        focus_prev_window();
+        focus().prev_window();
       }
     }
 
@@ -112,34 +120,6 @@ namespace ymwm::window {
       if (m_windows.end() != wit) {
         wit->name = std::move(new_name);
       }
-    }
-
-    inline void focus_next_window() noexcept {
-      update_focused_window_border(config::windows::regular_border_width,
-                                   config::windows::regular_border_color);
-      focus().next_window();
-      update_focused_window_border(config::windows::focused_border_width,
-                                   config::windows::focused_border_color);
-    }
-
-    inline void focus_prev_window() noexcept {
-      update_focused_window_border(config::windows::regular_border_width,
-                                   config::windows::regular_border_color);
-
-      focus().prev_window();
-
-      update_focused_window_border(config::windows::focused_border_width,
-                                   config::windows::focused_border_color);
-    }
-
-    inline void focus_last_window() noexcept {
-      update_focused_window_border(config::windows::regular_border_width,
-                                   config::windows::regular_border_color);
-
-      focus().last_window();
-
-      update_focused_window_border(config::windows::focused_border_width,
-                                   config::windows::focused_border_color);
     }
 
     inline FocusManager<Environment>& focus() noexcept {

--- a/src/window/Manager.h
+++ b/src/window/Manager.h
@@ -51,7 +51,6 @@ namespace ymwm::window {
 
       if (erased_successfully) {
         std::cout << std::format("Erased {} \n", id);
-        focus().update_index();
         focus().prev_window();
         layout().update();
       }


### PR DESCRIPTION
This PR refactors focus management.
Currently there are several places where Manager needs to update border width and color before moving focus from one window to another. This can be done internally by using callbacks from FocusManager. Also the update of focused window index must be entirely on FocusManager, not the Manager itself.