### PR TITLE
Implement StackVerticalLayout

### DIFF
--- a/src/config/Layout.h
+++ b/src/config/Layout.h
@@ -29,4 +29,10 @@ namespace ymwm::config::layouts {
     static constinit inline Margins grid_margins{ .horizontal = 0u,
                                                   .vertical = 0u };
   } // namespace grid
+
+  namespace stack_vertical_right {
+    static constinit inline unsigned int main_window_ratio{ 50 };
+    static constinit inline unsigned int main_window_margin{ 5 };
+    static constinit inline unsigned int stack_window_margin{ 5 };
+  } // namespace stack_vertical_right
 } // namespace ymwm::config::layouts

--- a/src/layouts/CMakeLists.txt
+++ b/src/layouts/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(layouts OBJECT
 	${CMAKE_CURRENT_SOURCE_DIR}/Maximized.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Grid.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalRight.cpp
 )
 target_include_directories(layouts PRIVATE
 	${TARGET_INCLUDE_DIRECTORY}

--- a/src/layouts/Parameters.h
+++ b/src/layouts/Parameters.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "config/Layout.h"
+#include "config/Window.h"
 
+#include <algorithm>
 #include <ranges>
 #include <variant>
 
@@ -29,6 +31,66 @@ namespace ymwm::layouts {
     }
   };
 
-  using Parameters = std::variant<MaximisedParameters, GridParameters>;
+  struct StackVerticalRight {
+    int screen_height_without_margins;
+    int two_borders{ std::min(config::windows::regular_border_width,
+                              config::windows::focused_border_width) *
+                     2 };
+    std::size_t number_of_stack_windows;
+    int height_of_stack_window{ 0 };
+    int width_of_stack_window{ 0 };
+    std::size_t last_iteration;
+    int stack_window_x;
+    int main_window_width;
+    int main_window_height;
+
+    inline StackVerticalRight(config::layouts::Margin screen_margins,
+                              int screen_width,
+                              int screen_height,
+                              std::size_t number_of_windows) {
+      namespace cfg = ymwm::config::layouts::stack_vertical_right;
+      int double_two_borders{ 2 * two_borders };
+
+      last_iteration = number_of_windows - 1ul;
+
+      number_of_stack_windows = number_of_windows - 1ul;
+
+      int screen_width_without_margins =
+          screen_width - screen_margins.left - screen_margins.right;
+      screen_height_without_margins =
+          screen_height - screen_margins.top - screen_margins.bottom;
+
+      unsigned int height_without_margins =
+          screen_height_without_margins -
+          (cfg::stack_window_margin * (number_of_stack_windows - 1ul));
+
+      unsigned int stack_window_ratio = 100u - cfg::main_window_ratio;
+
+      if (number_of_windows > 1ul) {
+        height_of_stack_window =
+            (height_without_margins - (two_borders * number_of_stack_windows)) /
+            number_of_stack_windows;
+
+        width_of_stack_window = (screen_width_without_margins -
+                                 cfg::main_window_margin - double_two_borders) *
+                                stack_window_ratio / 100;
+      }
+
+      stack_window_x = screen_margins.left +
+                       (screen_width_without_margins - cfg::main_window_margin -
+                        double_two_borders) *
+                           cfg::main_window_ratio / 100 +
+                       two_borders + cfg::main_window_margin;
+
+      main_window_width = (screen_width_without_margins -
+                           cfg::main_window_margin - double_two_borders) *
+                          cfg::main_window_ratio / 100;
+
+      main_window_height = screen_height_without_margins - two_borders;
+    }
+  };
+
+  using Parameters =
+      std::variant<MaximisedParameters, GridParameters, StackVerticalRight>;
 
 } // namespace ymwm::layouts

--- a/src/layouts/StackVerticalRight.cpp
+++ b/src/layouts/StackVerticalRight.cpp
@@ -1,0 +1,60 @@
+#include "Layout.h"
+#include "config/Layout.h"
+#include "layouts/Parameters.h"
+#include "window/Window.h"
+
+namespace ymwm::layouts {
+  template <>
+  void Layout::apply(const StackVerticalRight& parameters,
+                     window::Window& w) noexcept {
+    const auto& [screen_width,
+                 screen_height,
+                 screen_margins,
+                 number_of_windows] = basic_parameters;
+
+    const auto& [screen_height_without_margins,
+                 two_borders,
+                 number_of_stack_windows,
+                 height_of_stack_window,
+                 width_of_stack_window,
+                 last_iteration,
+                 stack_window_x,
+                 main_window_width,
+                 main_window_height] = parameters;
+
+    namespace cfg = ymwm::config::layouts::stack_vertical_right;
+
+    if (0ul == iteration) {
+      w.x = screen_margins.left;
+      w.y = screen_margins.top;
+      w.w = main_window_width;
+      w.h = main_window_height;
+      return;
+    }
+
+    w.x = stack_window_x;
+    w.y = screen_margins.top +
+          (iteration - 1ul) *
+              (height_of_stack_window + cfg::stack_window_margin + two_borders);
+    w.w = width_of_stack_window;
+    w.h = height_of_stack_window;
+
+    if (iteration == last_iteration) {
+      // Add missing units to height of last window so it lines up equally
+      // with main window. Units can be missing because of integer division.
+      w.h += screen_height_without_margins -
+             (height_of_stack_window * number_of_stack_windows +
+              two_borders * number_of_stack_windows +
+              cfg::stack_window_margin * (number_of_stack_windows - 1ul));
+    }
+  }
+
+  template <>
+  void Layout::update(const StackVerticalRight& parameters) noexcept {
+    this->parameters =
+        layouts::StackVerticalRight(basic_parameters.screen_margins,
+                                    basic_parameters.screen_width,
+                                    basic_parameters.screen_height,
+                                    basic_parameters.number_of_windows);
+  }
+} // namespace ymwm::layouts

--- a/tests/layouts/LayoutsTest.cpp
+++ b/tests/layouts/LayoutsTest.cpp
@@ -1,10 +1,27 @@
 #include "common/Color.h"
+#include "config/Layout.h"
+#include "config/Window.h"
 #include "layouts/Layout.h"
 #include "layouts/Parameters.h"
 #include "window/Window.h"
 
 #include <format>
 #include <gtest/gtest.h>
+
+static inline std::string
+window_to_string(const ymwm::window::Window& w) noexcept {
+  return std::format(
+      "id: {}; x: {}; y: {}; w: {}; h: {}; bw: {}; bc: {},{},{}\n",
+      w.id,
+      w.x,
+      w.y,
+      w.w,
+      w.h,
+      w.border_width,
+      w.border_color.red,
+      w.border_color.green,
+      w.border_color.blue);
+}
 
 static inline const ymwm::common::Color color(0xff, 0x0, 0x0);
 
@@ -302,6 +319,114 @@ TEST(TestLayouts, GridLayout_WithScreenMargins_AndGridMargins) {
     std::string result;
     for (const auto& w : test_windows) {
       result += std::format("{} {} {} {}\n", w.x, w.y, w.w, w.h);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackVerticalRight) {
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 7ul;
+
+  auto parameters =
+      ymwm::layouts::StackVerticalRight(basic_parameters.screen_margins,
+                                        basic_parameters.screen_width,
+                                        basic_parameters.screen_height,
+                                        basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50, ymwm::config::layouts::stack_vertical_right::main_window_ratio);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_vertical_right::main_window_margin);
+  ASSERT_EQ(5,
+            ymwm::config::layouts::stack_vertical_right::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 483,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 502,
+                           .y = 10,
+                           .w = 483,
+                           .h = 155,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 502,
+                           .y = 174,
+                           .w = 483,
+                           .h = 155,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 502,
+                           .y = 338,
+                           .w = 483,
+                           .h = 155,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 502,
+                           .y = 502,
+                           .w = 483,
+                           .h = 155,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 502,
+                           .y = 666,
+                           .w = 483,
+                           .h = 155,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 502,
+                           .y = 830,
+                           .w = 483,
+                           .h = 156,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(7ul, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
     }
     return result;
   }();

--- a/tests/window/WindowManagerTest.cpp
+++ b/tests/window/WindowManagerTest.cpp
@@ -340,6 +340,8 @@ TEST(TestWindowManager, MoveFocusedWindowBackward) {
       .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
 
   ymwm::window::Manager m{ &tenv };
+  m.layout().update(ymwm::config::layouts::maximized::screen_margins);
+  m.layout().update(ymwm::layouts::MaximisedParameters{});
 
   m.add_window(ymwm::window::Window{ .id = 1 });
   m.add_window(ymwm::window::Window{ .id = 2 });


### PR DESCRIPTION
This PR implements `StackVerticalRight` layout.
`StackVerticalRight` layout is a special windows layout where main window ( or first in stack ) is placed vertically with stacked windows on the right of the main window. This layout is helpful when user needs to concentrate on one task (window), but sometimes need small lookup to other windows.

Changes made:
- Implemented `StackVerticalRight` layout parameters and apply logic
- Add configuration for `StackVerticalRight` layout 
- Added tests for `StackVerticalRight` layout 