### PR TITLE
Remove `static` modifier from configuration variables

### DIFF
--- a/src/config/Layout.h
+++ b/src/config/Layout.h
@@ -9,30 +9,29 @@ namespace ymwm::config::layouts {
   };
 
   namespace maximized {
-    static constinit inline Margin screen_margins{ .left = 0u,
-                                                   .right = 0u,
-                                                   .top = 0u,
-                                                   .bottom = 0u };
+    constinit inline Margin screen_margins{ .left = 0u,
+                                            .right = 0u,
+                                            .top = 0u,
+                                            .bottom = 0u };
   }
 
   namespace grid {
-    static constinit inline Margin screen_margins{ .left = 0u,
-                                                   .right = 0u,
-                                                   .top = 0u,
-                                                   .bottom = 0u };
+    constinit inline Margin screen_margins{ .left = 0u,
+                                            .right = 0u,
+                                            .top = 0u,
+                                            .bottom = 0u };
 
     struct Margins {
       unsigned int horizontal;
       unsigned int vertical;
     };
 
-    static constinit inline Margins grid_margins{ .horizontal = 0u,
-                                                  .vertical = 0u };
+    constinit inline Margins grid_margins{ .horizontal = 0u, .vertical = 0u };
   } // namespace grid
 
   namespace stack_vertical_right {
-    static constinit inline unsigned int main_window_ratio{ 50 };
-    static constinit inline unsigned int main_window_margin{ 5 };
-    static constinit inline unsigned int stack_window_margin{ 5 };
+    constinit inline unsigned int main_window_ratio{ 50 };
+    constinit inline unsigned int main_window_margin{ 5 };
+    constinit inline unsigned int stack_window_margin{ 5 };
   } // namespace stack_vertical_right
 } // namespace ymwm::config::layouts

--- a/src/config/Window.h
+++ b/src/config/Window.h
@@ -3,8 +3,8 @@
 #include "common/Color.h"
 
 namespace ymwm::config::windows {
-  static inline ymwm::common::Color regular_border_color{ 0xff, 0x0, 0x0 };
-  static inline ymwm::common::Color focused_border_color{ 0x0, 0xff, 0x0 };
-  static constinit inline int regular_border_width{ 2 };
-  static constinit inline int focused_border_width{ 5 };
+  inline ymwm::common::Color regular_border_color{ 0xff, 0x0, 0x0 };
+  inline ymwm::common::Color focused_border_color{ 0x0, 0xff, 0x0 };
+  constinit inline int regular_border_width{ 2 };
+  constinit inline int focused_border_width{ 5 };
 } // namespace ymwm::config::windows


### PR DESCRIPTION
This PR fixes ability to share and modify global configuration for windows and layouts.

`static` causes variables to be unique for each compilation unit, meaning that each time header is included each configuration variable will copied, instead of being shared.
