### PR TITLE
Implement Ratio type

### DIFF
--- a/src/common/Ratio.h
+++ b/src/common/Ratio.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <algorithm>
+
+namespace ymwm::common {
+  struct Ratio {
+
+    inline Ratio(unsigned int value) noexcept
+        : m_value(std::clamp(value, min, max)) {}
+
+    inline operator unsigned int() const noexcept { return m_value; }
+
+  private:
+    static constexpr inline unsigned int max{ 100 };
+    static constexpr inline unsigned int min{ 0 };
+    int m_value;
+  };
+} // namespace ymwm::common

--- a/src/config/Layout.h
+++ b/src/config/Layout.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/Ratio.h"
 namespace ymwm::config::layouts {
   struct Margin {
     unsigned int left;
@@ -30,7 +31,7 @@ namespace ymwm::config::layouts {
   } // namespace grid
 
   namespace stack_vertical_right {
-    constinit inline unsigned int main_window_ratio{ 50 };
+    inline common::Ratio main_window_ratio{ 50 };
     constinit inline unsigned int main_window_margin{ 5 };
     constinit inline unsigned int stack_window_margin{ 5 };
   } // namespace stack_vertical_right

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRC_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src)
 include(${DEPENDENCIES}/gtest.cmake)
 enable_testing()
 
+add_subdirectory(common)
 add_subdirectory(events)
 add_subdirectory(layouts)
 add_subdirectory(window)

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(RatioTest
+	${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/RatioTest.cpp
+)
+target_include_directories(RatioTest
+	PUBLIC
+	${SRC_INCLUDE_DIR}
+	${GTEST_INCLUDE_DIRS}
+)
+target_link_libraries(RatioTest
+	${GTEST_LIBRARIES}
+	common
+)
+add_dependencies(RatioTest
+	googletestlib
+	common
+)
+add_test(NAME RatioTest COMMAND RatioTest WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/common/RatioTest.cpp
+++ b/tests/common/RatioTest.cpp
@@ -1,0 +1,16 @@
+#include "common/Ratio.h"
+
+#include <gtest/gtest.h>
+#include <ranges>
+
+TEST(TestRatio, InitWithInBoundValue) {
+  for (const auto v : std::ranges::views::iota(0u, 100u)) {
+    unsigned int value = ymwm::common::Ratio{ v };
+    ASSERT_EQ(v, value);
+  }
+}
+
+TEST(TestRatio, InitWithOverlappingValue) {
+  unsigned int value = ymwm::common::Ratio{ 101 };
+  EXPECT_EQ(100, value);
+}

--- a/tests/common/main.cpp
+++ b/tests/common/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR implements Ratio type. Ratio represents ratio(percentage) of window value relative to e.g. stack windows or
overall screen width/height itself. Ratio type utilize the restrictions
of having value in range of 0..100.