### PR TITLE
Refactor update of layout parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.9.1 LANGUAGES CXX)
+project(WindowManager VERSION 0.10.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/config/Layout.h
+++ b/src/config/Layout.h
@@ -9,19 +9,12 @@ namespace ymwm::config::layouts {
     unsigned int bottom;
   };
 
-  namespace maximized {
-    constinit inline Margin screen_margins{ .left = 0u,
-                                            .right = 0u,
-                                            .top = 0u,
-                                            .bottom = 0u };
-  }
+  constinit inline Margin screen_margins{ .left = 0u,
+                                          .right = 0u,
+                                          .top = 0u,
+                                          .bottom = 0u };
 
   namespace grid {
-    constinit inline Margin screen_margins{ .left = 0u,
-                                            .right = 0u,
-                                            .top = 0u,
-                                            .bottom = 0u };
-
     struct Margins {
       unsigned int horizontal;
       unsigned int vertical;

--- a/src/environment/x11/Environment.cpp
+++ b/src/environment/x11/Environment.cpp
@@ -82,12 +82,6 @@ namespace ymwm::environment {
                    m_handlers->root_window,
                    RevertToPointerRoot,
                    CurrentTime);
-
-    m_manager.layout().update(config::layouts::Margin{
-        .left = 10u, .right = 10u, .top = 10u, .bottom = 10u });
-    m_manager.layout().update(layouts::GridParameters(
-        config::layouts::grid::Margins{ .horizontal = 10u, .vertical = 20u },
-        4ul));
   }
 
   Environment::~Environment() {

--- a/src/layouts/Grid.cpp
+++ b/src/layouts/Grid.cpp
@@ -33,7 +33,7 @@ namespace ymwm::layouts {
 
   template <>
   void Layout::update(const GridParameters& parameters) noexcept {
-    this->parameters = layouts::GridParameters(
-        parameters.margins, this->basic_parameters.number_of_windows);
+    this->parameters =
+        layouts::GridParameters(this->basic_parameters.number_of_windows);
   }
 } // namespace ymwm::layouts

--- a/src/layouts/Parameters.h
+++ b/src/layouts/Parameters.h
@@ -15,9 +15,8 @@ namespace ymwm::layouts {
     unsigned int grid_size;
     unsigned int number_of_margins;
 
-    inline GridParameters(config::layouts::grid::Margins margins,
-                          std::size_t number_of_windows)
-        : margins(margins) {
+    inline GridParameters(std::size_t number_of_windows)
+        : margins(config::layouts::grid::grid_margins) {
       // For now Grid layout uses symmetric grid,
       // meaning 2x2, 3x3 and so on.
       for (std::size_t n : std::ranges::views::iota(2, 11)) {

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Window.h"
+#include "config/Layout.h"
 #include "layouts/Layout.h"
 
 #include <vector>
@@ -11,10 +12,6 @@ namespace ymwm::window {
     LayoutManager(std::vector<Window>& windows, Environment* const env)
         : m_windows(windows)
         , m_env(env) {}
-
-    inline void update(const config::layouts::Margin& screen_margins) {
-      m_basic_layout_parameters.screen_margins = screen_margins;
-    }
 
     inline void update(const layouts::Parameters& parameters) {
       m_layout_parameters = parameters;
@@ -39,6 +36,8 @@ namespace ymwm::window {
       m_basic_layout_parameters.screen_width = screen_width;
       m_basic_layout_parameters.screen_height = screen_height;
       m_basic_layout_parameters.number_of_windows = m_windows.size();
+      m_basic_layout_parameters.screen_margins =
+          config::layouts::screen_margins;
 
       auto layout =
           layouts::Layout{ .basic_parameters = m_basic_layout_parameters,

--- a/src/window/Manager.h
+++ b/src/window/Manager.h
@@ -3,6 +3,7 @@
 #include "LayoutManager.h"
 #include "Window.h"
 #include "common/Color.h"
+#include "config/Layout.h"
 #include "config/Window.h"
 #include "environment/ID.h"
 
@@ -30,6 +31,8 @@ namespace ymwm::window {
                                     config::windows::focused_border_color))
         , m_layout_manager(m_windows, env) {
       m_windows.reserve(5);
+
+      layout().update(layouts::GridParameters(5ul));
     }
 
     inline void add_window(const Window& w) noexcept {

--- a/tests/layouts/LayoutsTest.cpp
+++ b/tests/layouts/LayoutsTest.cpp
@@ -167,9 +167,7 @@ TEST(TestLayouts, GridLayout) {
   });
   ASSERT_EQ(4ul, expected_windows.size());
 
-  auto parameters = ymwm::layouts::GridParameters(
-      ymwm::config::layouts::grid::Margins{ .horizontal = 0u, .vertical = 0u },
-      test_windows.size());
+  auto parameters = ymwm::layouts::GridParameters(test_windows.size());
 
   auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
 
@@ -235,9 +233,7 @@ TEST(TestLayouts, GridLayout_WithScreenMargins) {
   });
   ASSERT_EQ(4ul, expected_windows.size());
 
-  auto parameters = ymwm::layouts::GridParameters(
-      ymwm::config::layouts::grid::Margins{ .horizontal = 0u, .vertical = 0u },
-      test_windows.size());
+  auto parameters = ymwm::layouts::GridParameters(test_windows.size());
 
   auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
 
@@ -303,10 +299,9 @@ TEST(TestLayouts, GridLayout_WithScreenMargins_AndGridMargins) {
   });
   ASSERT_EQ(4ul, expected_windows.size());
 
-  auto parameters = ymwm::layouts::GridParameters(
-      ymwm::config::layouts::grid::Margins{ .horizontal = 10u,
-                                            .vertical = 20u },
-      test_windows.size());
+  ymwm::config::layouts::grid::grid_margins.horizontal = 10u;
+  ymwm::config::layouts::grid::grid_margins.vertical = 20u;
+  auto parameters = ymwm::layouts::GridParameters(test_windows.size());
 
   auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
 

--- a/tests/window/WindowManagerTest.cpp
+++ b/tests/window/WindowManagerTest.cpp
@@ -96,7 +96,6 @@ TEST(TestWindowManager, AddRemoveWindows_LayoutAppliedAfterEachAction) {
 
   ymwm::window::Manager m{ &tenv };
 
-  m.layout().update(ymwm::config::layouts::maximized::screen_margins);
   m.layout().update(ymwm::layouts::MaximisedParameters{});
 
   EXPECT_CALL(tenv, screen_width_and_height);
@@ -166,7 +165,6 @@ TEST(TestWindowManager, MoveFocusedWindowToCoords) {
       .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
 
   ymwm::window::Manager m{ &tenv };
-  m.layout().update(ymwm::config::layouts::maximized::screen_margins);
   m.layout().update(ymwm::layouts::MaximisedParameters{});
 
   m.add_window(ymwm::window::Window{ .id = 1 });
@@ -208,7 +206,6 @@ TEST(TestWindowManager, ResetFocusIfWindowsAreRemoved) {
       .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
 
   ymwm::window::Manager m{ &tenv };
-  m.layout().update(ymwm::config::layouts::maximized::screen_margins);
   m.layout().update(ymwm::layouts::MaximisedParameters{});
 
   EXPECT_CALL(tenv, update_window_border).Times(2);
@@ -240,7 +237,6 @@ TEST(TestWindowManager, CloseFocusedWindow) {
       .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
 
   ymwm::window::Manager m{ &tenv };
-  m.layout().update(ymwm::config::layouts::maximized::screen_margins);
   m.layout().update(ymwm::layouts::MaximisedParameters{});
 
   EXPECT_CALL(tenv, update_window_border).Times(2);
@@ -281,7 +277,6 @@ TEST(TestWindowManager, MoveFocusedWindowForward) {
       .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
 
   ymwm::window::Manager m{ &tenv };
-  m.layout().update(ymwm::config::layouts::maximized::screen_margins);
   m.layout().update(ymwm::layouts::MaximisedParameters{});
 
   m.add_window(ymwm::window::Window{ .id = 1 });
@@ -340,7 +335,6 @@ TEST(TestWindowManager, MoveFocusedWindowBackward) {
       .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
 
   ymwm::window::Manager m{ &tenv };
-  m.layout().update(ymwm::config::layouts::maximized::screen_margins);
   m.layout().update(ymwm::layouts::MaximisedParameters{});
 
   m.add_window(ymwm::window::Window{ .id = 1 });


### PR DESCRIPTION
This PR implements refactoring for layout parameters update.
Screen margins for layout must be updated within LayoutManager, not the Environment, as well as setting initial Layout.
Also Grid layout should source margins from config, not the initial parameters.