### PR TITLE
Add keybinding to change layout interactively

### DIFF
--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -22,6 +22,7 @@ namespace ymwm::environment::commands {
   DEFINE_COMMAND(FocusPrevWindow)
   DEFINE_COMMAND(MoveFocusedWindowForward)
   DEFINE_COMMAND(MoveFocusedWindowBackward)
+  DEFINE_COMMAND(ChangeLayout)
 
   using Command = std::variant<ExitRequested,
                                RunTerminal,
@@ -31,7 +32,8 @@ namespace ymwm::environment::commands {
                                FocusNextWindow,
                                FocusPrevWindow,
                                MoveFocusedWindowForward,
-                               MoveFocusedWindowBackward>;
+                               MoveFocusedWindowBackward,
+                               ChangeLayout>;
 
   template <std::size_t Index =
                 std::variant_size_v<environment::commands::Command> - 1ul>

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -42,4 +42,8 @@ namespace ymwm::environment::commands {
   void MoveFocusedWindowBackward::execute(Environment& e) const {
     e.manager().move_focused_window_backward();
   }
+
+  void ChangeLayout::execute(Environment& e) const {
+    e.manager().layout().next();
+  }
 } // namespace ymwm::environment::commands

--- a/src/events/Map.cpp
+++ b/src/events/Map.cpp
@@ -54,6 +54,13 @@ namespace ymwm::events {
                     ymwm::events::AbstractKeyMask::Shift },
         ymwm::environment::commands::MoveFocusedWindowBackward{});
 
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::l,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Shift },
+        ymwm::environment::commands::ChangeLayout{});
+
     return bindings;
   }
 

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -2,6 +2,7 @@
 #include "Window.h"
 #include "config/Layout.h"
 #include "layouts/Layout.h"
+#include "layouts/Parameters.h"
 
 #include <vector>
 
@@ -27,6 +28,18 @@ namespace ymwm::window {
         layout.apply(w);
         m_env->move_and_resize(w);
       }
+    }
+
+    inline void next() noexcept {
+      static constexpr auto known_layouts = layouts::list_of_parameters();
+      auto current_layout_index = m_layout_parameters.index();
+      auto next_index = current_layout_index < (known_layouts.size() - 1ul)
+                            ? current_layout_index + 1ul
+                            : 0ul;
+
+      m_layout_parameters =
+          *layouts::try_find_parameters(known_layouts.at(next_index));
+      update();
     }
 
   private:


### PR DESCRIPTION
This PR implements `ChangeLayout` command and Alt+Shift+L default binding to command.