### PR TITLE
Implement StackHorizontal layouts

### DIFF
--- a/src/config/Layout.h
+++ b/src/config/Layout.h
@@ -32,6 +32,13 @@ namespace ymwm::config::layouts {
     constinit inline MarginType stack_window_margin{ 5 };
   } // namespace stack_vertical
 
+  namespace stack_horizontal {
+    using MainWindowRatioType = common::Ratio<10u, 90u>;
+    inline MainWindowRatioType main_window_ratio{ 50 };
+    constinit inline MarginType main_window_margin{ 5 };
+    constinit inline MarginType stack_window_margin{ 5 };
+  } // namespace stack_horizontal
+
   namespace parallel {
     constinit inline MarginType margin{ 2 };
   }

--- a/src/layouts/CMakeLists.txt
+++ b/src/layouts/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(layouts OBJECT
 	${CMAKE_CURRENT_SOURCE_DIR}/Grid.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalRight.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalLeft.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalTop.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ParallelVertical.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ParallelHorizontal.cpp
 )

--- a/src/layouts/CMakeLists.txt
+++ b/src/layouts/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(layouts OBJECT
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalRight.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalLeft.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalTop.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalBottom.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ParallelVertical.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ParallelHorizontal.cpp
 )

--- a/src/layouts/Parameters.h
+++ b/src/layouts/Parameters.h
@@ -3,6 +3,7 @@
 #include "Maximized.h"
 #include "ParallelHorizontal.h"
 #include "ParallelVertical.h"
+#include "StackHorizontalTop.h"
 #include "StackVerticalLeft.h"
 #include "StackVerticalRight.h"
 
@@ -17,6 +18,7 @@ namespace ymwm::layouts {
                                   Grid,
                                   StackVerticalRight,
                                   StackVerticalLeft,
+                                  StackHorizontalTop,
                                   ParallelVertical,
                                   ParallelHorizontal>;
 

--- a/src/layouts/Parameters.h
+++ b/src/layouts/Parameters.h
@@ -3,6 +3,7 @@
 #include "Maximized.h"
 #include "ParallelHorizontal.h"
 #include "ParallelVertical.h"
+#include "StackHorizontalBottom.h"
 #include "StackHorizontalTop.h"
 #include "StackVerticalLeft.h"
 #include "StackVerticalRight.h"
@@ -19,6 +20,7 @@ namespace ymwm::layouts {
                                   StackVerticalRight,
                                   StackVerticalLeft,
                                   StackHorizontalTop,
+                                  StackHorizontalBottom,
                                   ParallelVertical,
                                   ParallelHorizontal>;
 

--- a/src/layouts/StackHorizontalBottom.cpp
+++ b/src/layouts/StackHorizontalBottom.cpp
@@ -1,0 +1,87 @@
+#include "StackHorizontalBottom.h"
+
+#include "Layout.h"
+#include "config/Layout.h"
+#include "window/Window.h"
+
+namespace ymwm::layouts {
+  StackHorizontalBottom::StackHorizontalBottom() noexcept = default;
+
+  StackHorizontalBottom::StackHorizontalBottom(
+      config::layouts::Margin screen_margins,
+      int screen_width,
+      int screen_height,
+      std::size_t number_of_windows) noexcept {
+    namespace cfg = ymwm::config::layouts::stack_horizontal;
+
+    last_iteration = number_of_windows - 1ul;
+
+    int height_without_margins_and_borders =
+        screen_height - screen_margins.top - screen_margins.bottom -
+        cfg::main_window_margin - 2 * two_borders;
+    main_window_width =
+        screen_width - screen_margins.left - screen_margins.right - two_borders;
+    main_window_height =
+        height_without_margins_and_borders * cfg::main_window_ratio / 100;
+
+    std::size_t number_of_stack_windows = number_of_windows - 1ul;
+    stack_window_h = height_without_margins_and_borders *
+                     (100 - cfg::main_window_ratio) / 100;
+    stack_window_w =
+        (screen_width - screen_margins.left - screen_margins.right -
+         (number_of_windows * two_borders) -
+         (number_of_stack_windows - 1ul) * cfg::stack_window_margin) /
+        (number_of_stack_windows);
+  }
+
+  template <>
+  void Layout::apply(const StackHorizontalBottom& parameters,
+                     window::Window& w) noexcept {
+    const auto& [screen_width,
+                 screen_height,
+                 screen_margins,
+                 number_of_windows] = basic_parameters;
+
+    const auto& [last_iteration,
+                 two_borders,
+                 stack_window_h,
+                 stack_window_w,
+                 main_window_width,
+                 main_window_height] = parameters;
+
+    namespace cfg = ymwm::config::layouts::stack_horizontal;
+
+    if (0ul == iteration) {
+      w.x = screen_margins.left;
+      w.y = screen_margins.top + cfg::main_window_margin + two_borders +
+            stack_window_h;
+      w.w = main_window_width;
+      w.h = main_window_height;
+      return;
+    }
+
+    w.x = screen_margins.left +
+          (iteration - 1ul) *
+              (two_borders + cfg::stack_window_margin + stack_window_w);
+    w.y = screen_margins.top;
+    w.w = stack_window_w;
+    w.h = stack_window_h;
+
+    if (iteration == last_iteration) {
+      // Add missing units to height of last window so it lines up equally
+      // with main window. Units can be missing because of integer division.
+      w.w += screen_width - screen_margins.left - screen_margins.right -
+             ((two_borders + stack_window_w) * (number_of_windows - 1ul) +
+              cfg::stack_window_margin * (number_of_windows - 2ul));
+    }
+  }
+
+  template <>
+  void Layout::update(const StackHorizontalBottom& parameters) noexcept {
+    this->parameters =
+        layouts::StackHorizontalBottom(basic_parameters.screen_margins,
+                                       basic_parameters.screen_width,
+                                       basic_parameters.screen_height,
+                                       basic_parameters.number_of_windows);
+  }
+} // namespace ymwm::layouts

--- a/src/layouts/StackHorizontalBottom.h
+++ b/src/layouts/StackHorizontalBottom.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "config/Layout.h"
+#include "config/Window.h"
+
+#include <string_view>
+
+namespace ymwm::layouts {
+
+  struct StackHorizontalBottom {
+    static constexpr inline std::string_view type{ "StackHorizontalBottom" };
+
+    std::size_t last_iteration;
+    int two_borders{ std::max(config::windows::regular_border_width,
+                              config::windows::focused_border_width) *
+                     2 };
+    int stack_window_h{ 0 };
+    int stack_window_w{ 0 };
+    int main_window_width;
+    int main_window_height;
+
+    StackHorizontalBottom() noexcept;
+    StackHorizontalBottom(config::layouts::Margin screen_margins,
+                          int screen_width,
+                          int screen_height,
+                          std::size_t number_of_windows) noexcept;
+  };
+} // namespace ymwm::layouts

--- a/src/layouts/StackHorizontalTop.cpp
+++ b/src/layouts/StackHorizontalTop.cpp
@@ -1,0 +1,89 @@
+#include "StackHorizontalTop.h"
+
+#include "Layout.h"
+#include "config/Layout.h"
+#include "window/Window.h"
+
+namespace ymwm::layouts {
+  StackHorizontalTop::StackHorizontalTop() noexcept = default;
+
+  StackHorizontalTop::StackHorizontalTop(
+      config::layouts::Margin screen_margins,
+      int screen_width,
+      int screen_height,
+      std::size_t number_of_windows) noexcept {
+    namespace cfg = ymwm::config::layouts::stack_horizontal;
+
+    last_iteration = number_of_windows - 1ul;
+
+    int height_without_margins_and_borders =
+        screen_height - screen_margins.top - screen_margins.bottom -
+        cfg::main_window_margin - 2 * two_borders;
+    main_window_width =
+        screen_width - screen_margins.left - screen_margins.right - two_borders;
+    main_window_height =
+        height_without_margins_and_borders * cfg::main_window_ratio / 100;
+
+    std::size_t number_of_stack_windows = number_of_windows - 1ul;
+    stack_window_h = height_without_margins_and_borders *
+                     (100 - cfg::main_window_ratio) / 100;
+    stack_window_w =
+        (screen_width - screen_margins.left - screen_margins.right -
+         (number_of_windows * two_borders) -
+         (number_of_stack_windows - 1ul) * cfg::stack_window_margin) /
+        (number_of_stack_windows);
+    stack_window_y = screen_margins.top + cfg::main_window_margin +
+                     two_borders + main_window_height;
+  }
+
+  template <>
+  void Layout::apply(const StackHorizontalTop& parameters,
+                     window::Window& w) noexcept {
+    const auto& [screen_width,
+                 screen_height,
+                 screen_margins,
+                 number_of_windows] = basic_parameters;
+
+    const auto& [last_iteration,
+                 two_borders,
+                 stack_window_h,
+                 stack_window_w,
+                 stack_window_y,
+                 main_window_width,
+                 main_window_height] = parameters;
+
+    namespace cfg = ymwm::config::layouts::stack_horizontal;
+
+    if (0ul == iteration) {
+      w.x = screen_margins.left;
+      w.y = screen_margins.top;
+      w.w = main_window_width;
+      w.h = main_window_height;
+      return;
+    }
+
+    w.x = screen_margins.left +
+          (iteration - 1ul) *
+              (two_borders + cfg::stack_window_margin + stack_window_w);
+    w.y = stack_window_y;
+    w.w = stack_window_w;
+    w.h = stack_window_h;
+
+    if (iteration == last_iteration) {
+      // Add missing units to height of last window so it lines up equally
+      // with main window. Units can be missing because of integer division.
+      w.w += screen_width - screen_margins.left - screen_margins.right -
+             ((two_borders + stack_window_w) * (number_of_windows - 1ul) +
+              cfg::stack_window_margin * (number_of_windows - 2ul));
+    }
+  }
+
+  template <>
+  void Layout::update(const StackHorizontalTop& parameters) noexcept {
+    this->parameters =
+        layouts::StackHorizontalTop(basic_parameters.screen_margins,
+                                    basic_parameters.screen_width,
+                                    basic_parameters.screen_height,
+                                    basic_parameters.number_of_windows);
+  }
+} // namespace ymwm::layouts

--- a/src/layouts/StackHorizontalTop.h
+++ b/src/layouts/StackHorizontalTop.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "config/Layout.h"
+#include "config/Window.h"
+
+#include <string_view>
+
+namespace ymwm::layouts {
+
+  struct StackHorizontalTop {
+    static constexpr inline std::string_view type{ "StackHorizontalTop" };
+
+    std::size_t last_iteration;
+    int two_borders{ std::max(config::windows::regular_border_width,
+                              config::windows::focused_border_width) *
+                     2 };
+    int stack_window_h{ 0 };
+    int stack_window_w{ 0 };
+    int stack_window_y{ 0 };
+    int main_window_width;
+    int main_window_height;
+
+    StackHorizontalTop() noexcept;
+    StackHorizontalTop(config::layouts::Margin screen_margins,
+                       int screen_width,
+                       int screen_height,
+                       std::size_t number_of_windows) noexcept;
+  };
+} // namespace ymwm::layouts

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -4,6 +4,8 @@
 #include "config/Layout.h"
 #include "layouts/Layout.h"
 #include "layouts/Parameters.h"
+#include "layouts/StackHorizontalBottom.h"
+#include "layouts/StackHorizontalTop.h"
 
 #include <variant>
 #include <vector>
@@ -50,6 +52,16 @@ namespace ymwm::window {
           std::holds_alternative<layouts::StackVerticalLeft>(
               m_layout_parameters)) {
         namespace cfg = ymwm::config::layouts::stack_vertical;
+        cfg::main_window_ratio =
+            cfg::MainWindowRatioType{ cfg::main_window_ratio + diff };
+        update();
+      };
+
+      if (std::holds_alternative<layouts::StackHorizontalTop>(
+              m_layout_parameters) or
+          std::holds_alternative<layouts::StackHorizontalBottom>(
+              m_layout_parameters)) {
+        namespace cfg = ymwm::config::layouts::stack_horizontal;
         cfg::main_window_ratio =
             cfg::MainWindowRatioType{ cfg::main_window_ratio + diff };
         update();

--- a/tests/layouts/LayoutsTest.cpp
+++ b/tests/layouts/LayoutsTest.cpp
@@ -5,6 +5,8 @@
 #include "layouts/ParallelHorizontal.h"
 #include "layouts/ParallelVertical.h"
 #include "layouts/Parameters.h"
+#include "layouts/StackHorizontalBottom.h"
+#include "layouts/StackHorizontalTop.h"
 #include "window/Window.h"
 
 #include <format>
@@ -734,6 +736,192 @@ TEST(TestLayouts, ParallelHorizontal) {
   }();
 }
 
+TEST(TestLayouts, StackHorizontalTop) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_horizontal::main_window_ratio = 50;
+  ymwm::config::layouts::stack_horizontal::main_window_margin = 10;
+  ymwm::config::layouts::stack_horizontal::stack_window_margin = 10;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 4ul;
+
+  auto parameters =
+      ymwm::layouts::StackHorizontalTop(basic_parameters.screen_margins,
+                                        basic_parameters.screen_width,
+                                        basic_parameters.screen_height,
+                                        basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50u, ymwm::config::layouts::stack_horizontal::main_window_ratio);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_horizontal::main_window_margin);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_horizontal::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 976,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 505,
+                           .w = 314,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 338,
+                           .y = 505,
+                           .w = 314,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 666,
+                           .y = 505,
+                           // adjusted width
+                           .w = 320,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackHorizontalBottom) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_horizontal::main_window_ratio = 50;
+  ymwm::config::layouts::stack_horizontal::main_window_margin = 10;
+  ymwm::config::layouts::stack_horizontal::stack_window_margin = 10;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 4ul;
+
+  auto parameters =
+      ymwm::layouts::StackHorizontalBottom(basic_parameters.screen_margins,
+                                           basic_parameters.screen_width,
+                                           basic_parameters.screen_height,
+                                           basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50u, ymwm::config::layouts::stack_horizontal::main_window_ratio);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_horizontal::main_window_margin);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_horizontal::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 505,
+                           .w = 976,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 314,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 338,
+                           .y = 10,
+                           .w = 314,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 666,
+                           .y = 10,
+                           // adjusted width
+                           .w = 320,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
 TEST(TestLayouts, GetLayoutParametersFromString) {
   auto maximised_parameters =
       ymwm::layouts::try_find_parameters(ymwm::layouts::Maximised::type);
@@ -758,6 +946,18 @@ TEST(TestLayouts, GetLayoutParametersFromString) {
   ASSERT_TRUE(std::holds_alternative<ymwm::layouts::StackVerticalLeft>(
       *stack_vertical_parameters));
 
+  auto stack_horizontal_parameters = ymwm::layouts::try_find_parameters(
+      ymwm::layouts::StackHorizontalTop::type);
+  ASSERT_TRUE(stack_horizontal_parameters);
+  ASSERT_TRUE(std::holds_alternative<ymwm::layouts::StackHorizontalTop>(
+      *stack_horizontal_parameters));
+
+  stack_horizontal_parameters = ymwm::layouts::try_find_parameters(
+      ymwm::layouts::StackHorizontalBottom::type);
+  ASSERT_TRUE(stack_horizontal_parameters);
+  ASSERT_TRUE(std::holds_alternative<ymwm::layouts::StackHorizontalBottom>(
+      *stack_horizontal_parameters));
+
   auto parallel_parameters =
       ymwm::layouts::try_find_parameters(ymwm::layouts::ParallelVertical::type);
   ASSERT_TRUE(parallel_parameters);
@@ -778,6 +978,8 @@ TEST(TestLayouts, GetListOfLayoutsParameters) {
                                    ymwm::layouts::Grid::type,
                                    ymwm::layouts::StackVerticalRight::type,
                                    ymwm::layouts::StackVerticalLeft::type,
+                                   ymwm::layouts::StackHorizontalTop::type,
+                                   ymwm::layouts::StackHorizontalBottom::type,
                                    ymwm::layouts::ParallelVertical::type,
                                    ymwm::layouts::ParallelHorizontal::type));
 }


### PR DESCRIPTION
Similarly to `StackVertical`  `StackHorizontal` layouts place main window aside with stack window, but instead of placing left or right `StackHorizontal` layouts place main window above or below stacked windows.