### PR TITLE
Implement double stack layouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.16.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.17.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/layouts/CMakeLists.txt
+++ b/src/layouts/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(layouts OBJECT
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalDouble.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalTop.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalBottom.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalDouble.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ParallelVertical.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ParallelHorizontal.cpp
 )

--- a/src/layouts/CMakeLists.txt
+++ b/src/layouts/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(layouts OBJECT
 	${CMAKE_CURRENT_SOURCE_DIR}/Grid.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalRight.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalLeft.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalDouble.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalTop.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackHorizontalBottom.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ParallelVertical.cpp

--- a/src/layouts/Parameters.h
+++ b/src/layouts/Parameters.h
@@ -7,6 +7,7 @@
 #include "StackHorizontalTop.h"
 #include "StackVerticalLeft.h"
 #include "StackVerticalRight.h"
+#include "layouts/StackVerticalDouble.h"
 
 #include <array>
 #include <optional>
@@ -19,6 +20,7 @@ namespace ymwm::layouts {
                                   Grid,
                                   StackVerticalRight,
                                   StackVerticalLeft,
+                                  StackVerticalDouble,
                                   StackHorizontalTop,
                                   StackHorizontalBottom,
                                   ParallelVertical,

--- a/src/layouts/Parameters.h
+++ b/src/layouts/Parameters.h
@@ -4,10 +4,11 @@
 #include "ParallelHorizontal.h"
 #include "ParallelVertical.h"
 #include "StackHorizontalBottom.h"
+#include "StackHorizontalDouble.h"
 #include "StackHorizontalTop.h"
+#include "StackVerticalDouble.h"
 #include "StackVerticalLeft.h"
 #include "StackVerticalRight.h"
-#include "layouts/StackVerticalDouble.h"
 
 #include <array>
 #include <optional>
@@ -23,6 +24,7 @@ namespace ymwm::layouts {
                                   StackVerticalDouble,
                                   StackHorizontalTop,
                                   StackHorizontalBottom,
+                                  StackHorizontalDouble,
                                   ParallelVertical,
                                   ParallelHorizontal>;
 

--- a/src/layouts/StackHorizontalDouble.cpp
+++ b/src/layouts/StackHorizontalDouble.cpp
@@ -1,0 +1,111 @@
+#include "StackHorizontalDouble.h"
+
+#include "Layout.h"
+#include "config/Layout.h"
+#include "window/Window.h"
+
+namespace ymwm::layouts {
+  StackHorizontalDouble::StackHorizontalDouble() noexcept = default;
+
+  StackHorizontalDouble::StackHorizontalDouble(
+      config::layouts::Margin screen_margins,
+      int screen_width,
+      int screen_height,
+      std::size_t number_of_windows) noexcept {
+    namespace cfg = ymwm::config::layouts::stack_horizontal;
+
+    number_of_stack_windows = number_of_windows - 1ul;
+    number_of_windows_per_stack =
+        number_of_stack_windows / 2 +
+        static_cast<std::size_t>(0 != (number_of_stack_windows % 2));
+    last_iteration = number_of_windows - 1ul;
+    before_last_iteration = last_iteration - 1ul;
+
+    int height_without_margins =
+        screen_height - screen_margins.top - screen_margins.bottom;
+
+    width_without_margins =
+        screen_width - screen_margins.left - screen_margins.right;
+
+    int height_without_margins_borders =
+        screen_height - screen_margins.top - screen_margins.bottom -
+        (2 * cfg::stack_window_margin) - (3 * two_borders);
+
+    stack_window_h = (height_without_margins_borders *
+                      (100 - cfg::main_window_ratio) / 100) /
+                     2;
+
+    int stack_windows_width_without_margins_and_borders =
+        width_without_margins - (number_of_windows_per_stack * two_borders) -
+        (cfg::stack_window_margin * (number_of_windows_per_stack - 1ul));
+
+    stack_window_w = stack_windows_width_without_margins_and_borders /
+                     number_of_windows_per_stack;
+
+    main_window_w = width_without_margins - two_borders;
+    main_window_h =
+        height_without_margins_borders * cfg::main_window_ratio / 100;
+    main_window_y = screen_margins.top + two_borders + cfg::main_window_margin +
+                    stack_window_h;
+  }
+
+  template <>
+  void Layout::apply(const StackHorizontalDouble& parameters,
+                     window::Window& w) noexcept {
+    const auto& [screen_width,
+                 screen_height,
+                 screen_margins,
+                 number_of_windows] = basic_parameters;
+
+    const auto& [number_of_stack_windows,
+                 number_of_windows_per_stack,
+                 last_iteration,
+                 before_last_iteration,
+                 two_borders,
+                 width_without_margins,
+                 stack_window_w,
+                 stack_window_h,
+                 main_window_w,
+                 main_window_h,
+                 main_window_y] = parameters;
+
+    namespace cfg = ymwm::config::layouts::stack_vertical;
+
+    if (0ul == iteration) {
+      w.x = screen_margins.left;
+      w.y = main_window_y;
+      w.w = main_window_w;
+      w.h = main_window_h;
+      return;
+    }
+
+    auto q = (iteration - 1ul) % 2ul ? 1ul : 0ul;
+    w.y = screen_margins.top +
+          q * (stack_window_h + two_borders + (2 * cfg::main_window_margin) +
+               two_borders + main_window_h);
+    w.x = screen_margins.left +
+          ((iteration - 1ul) / 2) *
+              (two_borders + cfg::stack_window_margin + stack_window_w);
+    w.w = stack_window_w;
+    w.h = stack_window_h;
+
+    if (iteration == last_iteration or iteration == before_last_iteration) {
+      // Add missing units to height of last window so it lines up equally
+      // with main window. Units can be missing because of integer division.
+      auto margins =
+          cfg::stack_window_margin * (number_of_windows_per_stack - 1ul);
+      auto borders_and_widths =
+          (two_borders + stack_window_w) * number_of_windows_per_stack;
+      w.w += width_without_margins - margins - borders_and_widths;
+    }
+  }
+
+  template <>
+  void Layout::update(const StackHorizontalDouble& parameters) noexcept {
+    this->parameters =
+        layouts::StackHorizontalDouble(basic_parameters.screen_margins,
+                                       basic_parameters.screen_width,
+                                       basic_parameters.screen_height,
+                                       basic_parameters.number_of_windows);
+  }
+} // namespace ymwm::layouts

--- a/src/layouts/StackHorizontalDouble.h
+++ b/src/layouts/StackHorizontalDouble.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "config/Layout.h"
+#include "config/Window.h"
+
+#include <string_view>
+
+namespace ymwm::layouts {
+  struct StackHorizontalDouble {
+    static constexpr inline std::string_view type{ "StackHorizontalDouble" };
+
+    std::size_t number_of_stack_windows;
+    std::size_t number_of_windows_per_stack;
+    std::size_t last_iteration;
+    std::size_t before_last_iteration;
+
+    int two_borders{ std::max(config::windows::regular_border_width,
+                              config::windows::focused_border_width) *
+                     2 };
+    int width_without_margins;
+    int stack_window_w;
+    int stack_window_h;
+    int main_window_w;
+    int main_window_h;
+    int main_window_y;
+
+    StackHorizontalDouble() noexcept;
+    StackHorizontalDouble(config::layouts::Margin screen_margins,
+                          int screen_width,
+                          int screen_height,
+                          std::size_t number_of_windows) noexcept;
+  };
+} // namespace ymwm::layouts

--- a/src/layouts/StackVerticalDouble.cpp
+++ b/src/layouts/StackVerticalDouble.cpp
@@ -1,0 +1,109 @@
+#include "StackVerticalDouble.h"
+
+#include "Layout.h"
+#include "config/Layout.h"
+#include "window/Window.h"
+
+namespace ymwm::layouts {
+  StackVerticalDouble::StackVerticalDouble() noexcept = default;
+
+  StackVerticalDouble::StackVerticalDouble(
+      config::layouts::Margin screen_margins,
+      int screen_width,
+      int screen_height,
+      std::size_t number_of_windows) noexcept {
+    namespace cfg = ymwm::config::layouts::stack_vertical;
+
+    number_of_stack_windows = number_of_windows - 1ul;
+    number_of_windows_per_stack =
+        number_of_stack_windows / 2 +
+        static_cast<std::size_t>(0 != (number_of_stack_windows % 2));
+    last_iteration = number_of_windows - 1ul;
+    before_last_iteration = last_iteration - 1ul;
+
+    height_without_margins =
+        screen_height - screen_margins.top - screen_margins.bottom;
+
+    int width_without_margins_borders =
+        screen_width - screen_margins.left - screen_margins.right -
+        (2 * cfg::stack_window_margin) - (3 * two_borders);
+
+    main_window_w =
+        width_without_margins_borders * cfg::main_window_ratio / 100;
+    main_window_h = height_without_margins - two_borders;
+    main_window_x = screen_margins.left + two_borders +
+                    cfg::main_window_margin +
+                    ((width_without_margins_borders - main_window_w) / 2);
+
+    stack_window_w =
+        (width_without_margins_borders * (100 - cfg::main_window_ratio) / 100) /
+        2;
+
+    int stack_windows_height_without_margins_and_borders =
+        height_without_margins - (number_of_windows_per_stack * two_borders) -
+        ((number_of_windows_per_stack - 1ul) * cfg::stack_window_margin);
+
+    stack_window_h = stack_windows_height_without_margins_and_borders /
+                     number_of_windows_per_stack;
+  }
+
+  template <>
+  void Layout::apply(const StackVerticalDouble& parameters,
+                     window::Window& w) noexcept {
+    const auto& [screen_width,
+                 screen_height,
+                 screen_margins,
+                 number_of_windows] = basic_parameters;
+
+    const auto& [number_of_stack_windows,
+                 number_of_windows_per_stack,
+                 last_iteration,
+                 before_last_iteration,
+                 two_borders,
+                 height_without_margins,
+                 stack_window_w,
+                 stack_window_h,
+                 main_window_w,
+                 main_window_h,
+                 main_window_x] = parameters;
+
+    namespace cfg = ymwm::config::layouts::stack_vertical;
+
+    if (0ul == iteration) {
+      w.x = main_window_x;
+      w.y = screen_margins.top;
+      w.w = main_window_w;
+      w.h = main_window_h;
+      return;
+    }
+
+    auto q = (iteration - 1ul) % 2ul ? 1ul : 0ul;
+    w.x = screen_margins.left +
+          q * (stack_window_w + two_borders + (2 * cfg::main_window_margin) +
+               two_borders + main_window_w);
+    w.y = screen_margins.top +
+          ((iteration - 1ul) / 2) *
+              (two_borders + cfg::stack_window_margin + stack_window_h);
+    w.w = stack_window_w;
+    w.h = stack_window_h;
+
+    if (iteration == last_iteration or iteration == before_last_iteration) {
+      // Add missing units to height of last window so it lines up equally
+      // with main window. Units can be missing because of integer division.
+      auto margins =
+          cfg::stack_window_margin * (number_of_windows_per_stack - 1ul);
+      auto borders_and_widths =
+          (two_borders + stack_window_h) * number_of_windows_per_stack;
+      w.h += height_without_margins - margins - borders_and_widths;
+    }
+  }
+
+  template <>
+  void Layout::update(const StackVerticalDouble& parameters) noexcept {
+    this->parameters =
+        layouts::StackVerticalDouble(basic_parameters.screen_margins,
+                                     basic_parameters.screen_width,
+                                     basic_parameters.screen_height,
+                                     basic_parameters.number_of_windows);
+  }
+} // namespace ymwm::layouts

--- a/src/layouts/StackVerticalDouble.h
+++ b/src/layouts/StackVerticalDouble.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "config/Layout.h"
+#include "config/Window.h"
+
+#include <string_view>
+
+namespace ymwm::layouts {
+  struct StackVerticalDouble {
+    static constexpr inline std::string_view type{ "StackVerticalDouble" };
+
+    std::size_t number_of_stack_windows;
+    std::size_t number_of_windows_per_stack;
+    std::size_t last_iteration;
+    std::size_t before_last_iteration;
+
+    int two_borders{ std::max(config::windows::regular_border_width,
+                              config::windows::focused_border_width) *
+                     2 };
+    int height_without_margins;
+    int stack_window_w;
+    int stack_window_h;
+    int main_window_w;
+    int main_window_h;
+    int main_window_x;
+
+    StackVerticalDouble() noexcept;
+    StackVerticalDouble(config::layouts::Margin screen_margins,
+                        int screen_width,
+                        int screen_height,
+                        std::size_t number_of_windows) noexcept;
+  };
+} // namespace ymwm::layouts

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -50,6 +50,8 @@ namespace ymwm::window {
       if (std::holds_alternative<layouts::StackVerticalRight>(
               m_layout_parameters) or
           std::holds_alternative<layouts::StackVerticalLeft>(
+              m_layout_parameters) or
+          std::holds_alternative<layouts::StackVerticalDouble>(
               m_layout_parameters)) {
         namespace cfg = ymwm::config::layouts::stack_vertical;
         cfg::main_window_ratio =
@@ -60,6 +62,8 @@ namespace ymwm::window {
       if (std::holds_alternative<layouts::StackHorizontalTop>(
               m_layout_parameters) or
           std::holds_alternative<layouts::StackHorizontalBottom>(
+              m_layout_parameters) or
+          std::holds_alternative<layouts::StackHorizontalDouble>(
               m_layout_parameters)) {
         namespace cfg = ymwm::config::layouts::stack_horizontal;
         cfg::main_window_ratio =

--- a/tests/layouts/LayoutsTest.cpp
+++ b/tests/layouts/LayoutsTest.cpp
@@ -6,7 +6,9 @@
 #include "layouts/ParallelVertical.h"
 #include "layouts/Parameters.h"
 #include "layouts/StackHorizontalBottom.h"
+#include "layouts/StackHorizontalDouble.h"
 #include "layouts/StackHorizontalTop.h"
+#include "layouts/StackVerticalDouble.h"
 #include "window/Window.h"
 
 #include <format>
@@ -922,6 +924,204 @@ TEST(TestLayouts, StackHorizontalBottom) {
   }();
 }
 
+TEST(TestLayouts, StackVerticalDouble) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_vertical::main_window_ratio = 50;
+  ymwm::config::layouts::stack_vertical::main_window_margin = 10;
+  ymwm::config::layouts::stack_vertical::stack_window_margin = 10;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 5ul;
+
+  auto parameters =
+      ymwm::layouts::StackVerticalDouble(basic_parameters.screen_margins,
+                                         basic_parameters.screen_width,
+                                         basic_parameters.screen_height,
+                                         basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50u, ymwm::config::layouts::stack_vertical::main_window_ratio);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_vertical::main_window_margin);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_vertical::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 261,
+                           .y = 10,
+                           .w = 474,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 237,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 749,
+                           .y = 10,
+                           .w = 237,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 505,
+                           .w = 237,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 749,
+                           .y = 505,
+                           .w = 237,
+                           .h = 481,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackHorizontalDouble) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_horizontal::main_window_ratio = 50;
+  ymwm::config::layouts::stack_horizontal::main_window_margin = 10;
+  ymwm::config::layouts::stack_horizontal::stack_window_margin = 10;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 5ul;
+
+  auto parameters =
+      ymwm::layouts::StackHorizontalDouble(basic_parameters.screen_margins,
+                                           basic_parameters.screen_width,
+                                           basic_parameters.screen_height,
+                                           basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50u, ymwm::config::layouts::stack_horizontal::main_window_ratio);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_horizontal::main_window_margin);
+  ASSERT_EQ(10u, ymwm::config::layouts::stack_horizontal::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 261,
+                           .w = 976,
+                           .h = 474,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 481,
+                           .h = 237,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 749,
+                           .w = 481,
+                           .h = 237,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 505,
+                           .y = 10,
+                           .w = 481,
+                           .h = 237,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+      ymwm::window::Window{
+                           .x = 505,
+                           .y = 749,
+                           .w = 481,
+                           .h = 237,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
 TEST(TestLayouts, GetLayoutParametersFromString) {
   auto maximised_parameters =
       ymwm::layouts::try_find_parameters(ymwm::layouts::Maximised::type);
@@ -946,6 +1146,12 @@ TEST(TestLayouts, GetLayoutParametersFromString) {
   ASSERT_TRUE(std::holds_alternative<ymwm::layouts::StackVerticalLeft>(
       *stack_vertical_parameters));
 
+  stack_vertical_parameters = ymwm::layouts::try_find_parameters(
+      ymwm::layouts::StackVerticalDouble::type);
+  ASSERT_TRUE(stack_vertical_parameters);
+  ASSERT_TRUE(std::holds_alternative<ymwm::layouts::StackVerticalDouble>(
+      *stack_vertical_parameters));
+
   auto stack_horizontal_parameters = ymwm::layouts::try_find_parameters(
       ymwm::layouts::StackHorizontalTop::type);
   ASSERT_TRUE(stack_horizontal_parameters);
@@ -956,6 +1162,12 @@ TEST(TestLayouts, GetLayoutParametersFromString) {
       ymwm::layouts::StackHorizontalBottom::type);
   ASSERT_TRUE(stack_horizontal_parameters);
   ASSERT_TRUE(std::holds_alternative<ymwm::layouts::StackHorizontalBottom>(
+      *stack_horizontal_parameters));
+
+  stack_horizontal_parameters = ymwm::layouts::try_find_parameters(
+      ymwm::layouts::StackHorizontalDouble::type);
+  ASSERT_TRUE(stack_horizontal_parameters);
+  ASSERT_TRUE(std::holds_alternative<ymwm::layouts::StackHorizontalDouble>(
       *stack_horizontal_parameters));
 
   auto parallel_parameters =
@@ -978,8 +1190,10 @@ TEST(TestLayouts, GetListOfLayoutsParameters) {
                                    ymwm::layouts::Grid::type,
                                    ymwm::layouts::StackVerticalRight::type,
                                    ymwm::layouts::StackVerticalLeft::type,
+                                   ymwm::layouts::StackVerticalDouble::type,
                                    ymwm::layouts::StackHorizontalTop::type,
                                    ymwm::layouts::StackHorizontalBottom::type,
+                                   ymwm::layouts::StackHorizontalDouble::type,
                                    ymwm::layouts::ParallelVertical::type,
                                    ymwm::layouts::ParallelHorizontal::type));
 }


### PR DESCRIPTION
Double stack layouts are similar to StackVertical and StackHorizontal Left/Right layouts, except of having 2 stacks aside from main window. One of the stacks contains all odd-numbered windows and the other one - even-numbered. This layout allows to have main window centered by screen and have other windows present on both sides, which enhances UX of concentrating user attention on main window. 