### PR TITLE
Fix floating point exception for stack layouts

### DIFF
--- a/src/layouts/StackHorizontalBottom.cpp
+++ b/src/layouts/StackHorizontalBottom.cpp
@@ -15,6 +15,7 @@ namespace ymwm::layouts {
     namespace cfg = ymwm::config::layouts::stack_horizontal;
 
     last_iteration = number_of_windows - 1ul;
+    std::size_t number_of_stack_windows = number_of_windows - 1ul;
 
     int height_without_margins_and_borders =
         screen_height - screen_margins.top - screen_margins.bottom -
@@ -22,16 +23,20 @@ namespace ymwm::layouts {
     main_window_width =
         screen_width - screen_margins.left - screen_margins.right - two_borders;
     main_window_height =
-        height_without_margins_and_borders * cfg::main_window_ratio / 100;
+        number_of_stack_windows > 0ul
+            ? height_without_margins_and_borders * cfg::main_window_ratio / 100
+            : (screen_height - screen_margins.top - screen_margins.bottom -
+               two_borders);
 
-    std::size_t number_of_stack_windows = number_of_windows - 1ul;
     stack_window_h = height_without_margins_and_borders *
                      (100 - cfg::main_window_ratio) / 100;
-    stack_window_w =
-        (screen_width - screen_margins.left - screen_margins.right -
-         (number_of_windows * two_borders) -
-         (number_of_stack_windows - 1ul) * cfg::stack_window_margin) /
-        (number_of_stack_windows);
+    if (number_of_stack_windows > 0ul) {
+      stack_window_w =
+          (screen_width - screen_margins.left - screen_margins.right -
+           (number_of_windows * two_borders) -
+           (number_of_stack_windows - 1ul) * cfg::stack_window_margin) /
+          (number_of_stack_windows);
+    }
   }
 
   template <>
@@ -53,8 +58,10 @@ namespace ymwm::layouts {
 
     if (0ul == iteration) {
       w.x = screen_margins.left;
-      w.y = screen_margins.top + cfg::main_window_margin + two_borders +
-            stack_window_h;
+      w.y = number_of_windows > 1ul
+                ? screen_margins.top + cfg::main_window_margin + two_borders +
+                      stack_window_h
+                : screen_margins.top;
       w.w = main_window_width;
       w.h = main_window_height;
       return;

--- a/src/layouts/StackHorizontalDouble.cpp
+++ b/src/layouts/StackHorizontalDouble.cpp
@@ -39,14 +39,22 @@ namespace ymwm::layouts {
         width_without_margins - (number_of_windows_per_stack * two_borders) -
         (cfg::stack_window_margin * (number_of_windows_per_stack - 1ul));
 
-    stack_window_w = stack_windows_width_without_margins_and_borders /
-                     number_of_windows_per_stack;
+    stack_window_w = number_of_stack_windows > 0ul
+                         ? stack_windows_width_without_margins_and_borders /
+                               number_of_windows_per_stack
+                         : 0;
 
     main_window_w = width_without_margins - two_borders;
     main_window_h =
-        height_without_margins_borders * cfg::main_window_ratio / 100;
-    main_window_y = screen_margins.top + two_borders + cfg::main_window_margin +
-                    stack_window_h;
+        number_of_stack_windows > 0ul
+            ? height_without_margins_borders * cfg::main_window_ratio / 100
+            : (screen_height - screen_margins.top - screen_margins.bottom -
+               two_borders);
+    main_window_y =
+        screen_margins.top +
+        (number_of_stack_windows > 0ul
+             ? two_borders + cfg::main_window_margin + stack_window_h
+             : 0);
   }
 
   template <>

--- a/src/layouts/StackHorizontalTop.cpp
+++ b/src/layouts/StackHorizontalTop.cpp
@@ -15,6 +15,7 @@ namespace ymwm::layouts {
     namespace cfg = ymwm::config::layouts::stack_horizontal;
 
     last_iteration = number_of_windows - 1ul;
+    std::size_t number_of_stack_windows = number_of_windows - 1ul;
 
     int height_without_margins_and_borders =
         screen_height - screen_margins.top - screen_margins.bottom -
@@ -22,16 +23,20 @@ namespace ymwm::layouts {
     main_window_width =
         screen_width - screen_margins.left - screen_margins.right - two_borders;
     main_window_height =
-        height_without_margins_and_borders * cfg::main_window_ratio / 100;
+        number_of_stack_windows > 0ul
+            ? height_without_margins_and_borders * cfg::main_window_ratio / 100
+            : (screen_height - screen_margins.top - screen_margins.bottom -
+               two_borders);
 
-    std::size_t number_of_stack_windows = number_of_windows - 1ul;
     stack_window_h = height_without_margins_and_borders *
                      (100 - cfg::main_window_ratio) / 100;
-    stack_window_w =
-        (screen_width - screen_margins.left - screen_margins.right -
-         (number_of_windows * two_borders) -
-         (number_of_stack_windows - 1ul) * cfg::stack_window_margin) /
-        (number_of_stack_windows);
+    if (number_of_stack_windows > 0ul) {
+      stack_window_w =
+          (screen_width - screen_margins.left - screen_margins.right -
+           (number_of_windows * two_borders) -
+           (number_of_stack_windows - 1ul) * cfg::stack_window_margin) /
+          (number_of_stack_windows);
+    }
     stack_window_y = screen_margins.top + cfg::main_window_margin +
                      two_borders + main_window_height;
   }

--- a/src/layouts/StackVerticalDouble.cpp
+++ b/src/layouts/StackVerticalDouble.cpp
@@ -29,11 +29,17 @@ namespace ymwm::layouts {
         (2 * cfg::stack_window_margin) - (3 * two_borders);
 
     main_window_w =
-        width_without_margins_borders * cfg::main_window_ratio / 100;
+        number_of_stack_windows > 0ul
+            ? width_without_margins_borders * cfg::main_window_ratio / 100
+            : (screen_width - screen_margins.left - screen_margins.right -
+               two_borders);
     main_window_h = height_without_margins - two_borders;
-    main_window_x = screen_margins.left + two_borders +
-                    cfg::main_window_margin +
-                    ((width_without_margins_borders - main_window_w) / 2);
+    main_window_x =
+        screen_margins.left +
+        (number_of_stack_windows > 0ul
+             ? two_borders + cfg::main_window_margin +
+                   ((width_without_margins_borders - main_window_w) / 2)
+             : 0);
 
     stack_window_w =
         (width_without_margins_borders * (100 - cfg::main_window_ratio) / 100) /
@@ -43,8 +49,10 @@ namespace ymwm::layouts {
         height_without_margins - (number_of_windows_per_stack * two_borders) -
         ((number_of_windows_per_stack - 1ul) * cfg::stack_window_margin);
 
-    stack_window_h = stack_windows_height_without_margins_and_borders /
-                     number_of_windows_per_stack;
+    stack_window_h = number_of_stack_windows > 0ul
+                         ? stack_windows_height_without_margins_and_borders /
+                               number_of_windows_per_stack
+                         : 0;
   }
 
   template <>

--- a/src/layouts/StackVerticalLeft.cpp
+++ b/src/layouts/StackVerticalLeft.cpp
@@ -39,9 +39,12 @@ namespace ymwm::layouts {
                               stack_window_ratio / 100;
     }
 
-    main_window_width = (screen_width_without_margins -
-                         cfg::main_window_margin - double_two_borders) *
-                        cfg::main_window_ratio / 100;
+    main_window_width = number_of_stack_windows > 0ul
+                            ? (screen_width_without_margins -
+                               cfg::main_window_margin - double_two_borders) *
+                                  cfg::main_window_ratio / 100
+                            : (screen_width - screen_margins.left -
+                               screen_margins.right - two_borders);
 
     main_window_height = screen_height_without_margins - two_borders;
   }
@@ -66,8 +69,12 @@ namespace ymwm::layouts {
     namespace cfg = ymwm::config::layouts::stack_vertical;
 
     if (0ul == iteration) {
-      w.x = screen_margins.left + two_borders + cfg::main_window_margin +
-            width_of_stack_window;
+      w.x = screen_margins.left;
+      if (number_of_stack_windows > 0ul) {
+        w.x = screen_margins.left + two_borders + cfg::main_window_margin +
+              width_of_stack_window;
+      }
+
       w.y = screen_margins.top;
       w.w = main_window_width;
       w.h = main_window_height;

--- a/src/layouts/StackVerticalRight.cpp
+++ b/src/layouts/StackVerticalRight.cpp
@@ -46,9 +46,12 @@ namespace ymwm::layouts {
                          cfg::main_window_ratio / 100 +
                      two_borders + cfg::main_window_margin;
 
-    main_window_width = (screen_width_without_margins -
-                         cfg::main_window_margin - double_two_borders) *
-                        cfg::main_window_ratio / 100;
+    main_window_width = number_of_stack_windows > 0ul
+                            ? (screen_width_without_margins -
+                               cfg::main_window_margin - double_two_borders) *
+                                  cfg::main_window_ratio / 100
+                            : (screen_width - screen_margins.left -
+                               screen_margins.right - two_borders);
 
     main_window_height = screen_height_without_margins - two_borders;
   }

--- a/tests/layouts/LayoutsTest.cpp
+++ b/tests/layouts/LayoutsTest.cpp
@@ -1122,6 +1122,432 @@ TEST(TestLayouts, StackHorizontalDouble) {
   }();
 }
 
+TEST(TestLayouts, StackVerticalRightLayout_MainWindowOnly) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_vertical::main_window_ratio = 50;
+  ymwm::config::layouts::stack_vertical::main_window_margin = 5;
+  ymwm::config::layouts::stack_vertical::stack_window_margin = 5;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 1ul;
+
+  auto parameters =
+      ymwm::layouts::StackVerticalRight(basic_parameters.screen_margins,
+                                        basic_parameters.screen_width,
+                                        basic_parameters.screen_height,
+                                        basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50, ymwm::config::layouts::stack_vertical::main_window_ratio);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_vertical::main_window_margin);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_vertical::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 976,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackVerticalLeftLayout_MainWindowOnly) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_vertical::main_window_ratio = 50;
+  ymwm::config::layouts::stack_vertical::main_window_margin = 5;
+  ymwm::config::layouts::stack_vertical::stack_window_margin = 5;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 1ul;
+
+  auto parameters =
+      ymwm::layouts::StackVerticalLeft(basic_parameters.screen_margins,
+                                       basic_parameters.screen_width,
+                                       basic_parameters.screen_height,
+                                       basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50, ymwm::config::layouts::stack_vertical::main_window_ratio);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_vertical::main_window_margin);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_vertical::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 976,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackHorizontalTopLayout_MainWindowOnly) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_horizontal::main_window_ratio = 50;
+  ymwm::config::layouts::stack_horizontal::main_window_margin = 5;
+  ymwm::config::layouts::stack_horizontal::stack_window_margin = 5;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 1ul;
+
+  auto parameters =
+      ymwm::layouts::StackHorizontalTop(basic_parameters.screen_margins,
+                                        basic_parameters.screen_width,
+                                        basic_parameters.screen_height,
+                                        basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50, ymwm::config::layouts::stack_horizontal::main_window_ratio);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_horizontal::main_window_margin);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_horizontal::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 976,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackHorizontalBottomLayout_MainWindowOnly) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_horizontal::main_window_ratio = 50;
+  ymwm::config::layouts::stack_horizontal::main_window_margin = 5;
+  ymwm::config::layouts::stack_horizontal::stack_window_margin = 5;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 1ul;
+
+  auto parameters =
+      ymwm::layouts::StackHorizontalBottom(basic_parameters.screen_margins,
+                                           basic_parameters.screen_width,
+                                           basic_parameters.screen_height,
+                                           basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50, ymwm::config::layouts::stack_horizontal::main_window_ratio);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_horizontal::main_window_margin);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_horizontal::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 976,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackVerticalDoubleLayout_MainWindowOnly) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_vertical::main_window_ratio = 50;
+  ymwm::config::layouts::stack_vertical::main_window_margin = 5;
+  ymwm::config::layouts::stack_vertical::stack_window_margin = 5;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 1ul;
+
+  auto parameters =
+      ymwm::layouts::StackVerticalDouble(basic_parameters.screen_margins,
+                                         basic_parameters.screen_width,
+                                         basic_parameters.screen_height,
+                                         basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50, ymwm::config::layouts::stack_vertical::main_window_ratio);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_vertical::main_window_margin);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_vertical::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 976,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
+TEST(TestLayouts, StackHorizontalDoubleLayout_MainWindowOnly) {
+  ymwm::config::windows::regular_border_width = 0;
+  ymwm::config::windows::focused_border_width = 2;
+  ymwm::config::layouts::stack_horizontal::main_window_ratio = 50;
+  ymwm::config::layouts::stack_horizontal::main_window_margin = 5;
+  ymwm::config::layouts::stack_horizontal::stack_window_margin = 5;
+
+  ymwm::layouts::Layout::BasicParameters basic_parameters;
+  basic_parameters.screen_width = 1000;
+  basic_parameters.screen_height = 1000;
+  basic_parameters.screen_margins.left = 10u;
+  basic_parameters.screen_margins.right = 10u;
+  basic_parameters.screen_margins.top = 10u;
+  basic_parameters.screen_margins.bottom = 10u;
+  basic_parameters.number_of_windows = 1ul;
+
+  auto parameters =
+      ymwm::layouts::StackHorizontalDouble(basic_parameters.screen_margins,
+                                           basic_parameters.screen_width,
+                                           basic_parameters.screen_height,
+                                           basic_parameters.number_of_windows);
+
+  std::vector<ymwm::window::Window> test_windows(
+      basic_parameters.number_of_windows,
+      ymwm::window::Window{
+          .x = 0,
+          .y = 0,
+          .w = 200,
+          .h = 200,
+          .border_width = ymwm::config::windows::regular_border_width,
+          .border_color = ymwm::config::windows::regular_border_color });
+  ASSERT_EQ(basic_parameters.number_of_windows, test_windows.size());
+
+  ASSERT_EQ(10, basic_parameters.screen_margins.left);
+  ASSERT_EQ(10, basic_parameters.screen_margins.right);
+  ASSERT_EQ(10, basic_parameters.screen_margins.top);
+  ASSERT_EQ(10, basic_parameters.screen_margins.bottom);
+  ASSERT_EQ(50, ymwm::config::layouts::stack_horizontal::main_window_ratio);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_horizontal::main_window_margin);
+  ASSERT_EQ(5, ymwm::config::layouts::stack_horizontal::stack_window_margin);
+  ASSERT_EQ(1000, basic_parameters.screen_width);
+  ASSERT_EQ(1000, basic_parameters.screen_height);
+  ASSERT_EQ(4, parameters.two_borders);
+
+  std::vector<ymwm::window::Window> expected_windows({
+      ymwm::window::Window{
+                           .x = 10,
+                           .y = 10,
+                           .w = 976,
+                           .h = 976,
+                           .border_width = ymwm::config::windows::regular_border_width,
+                           .border_color = ymwm::config::windows::regular_border_color },
+  });
+  ASSERT_EQ(basic_parameters.number_of_windows, expected_windows.size());
+
+  auto prepared_layout = ymwm::layouts::Layout(basic_parameters, parameters);
+
+  for (auto& w : test_windows) {
+    prepared_layout.apply(w);
+  }
+
+  EXPECT_EQ(test_windows, expected_windows)
+      << [&test_windows]() -> std::string {
+    std::string result;
+    for (const auto& w : test_windows) {
+      result += window_to_string(w);
+    }
+    return result;
+  }();
+}
+
 TEST(TestLayouts, GetLayoutParametersFromString) {
   auto maximised_parameters =
       ymwm::layouts::try_find_parameters(ymwm::layouts::Maximised::type);


### PR DESCRIPTION
When there are no stack windows in stack layout but only main remains, the floating point exception occurs, caused by division on 0. Besides, when there are no windows in stack, it is more valuable to show main window maximized.