### PR TITLE
Focus window after EnterNotify event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.20.5 LANGUAGES CXX)
+project(WindowManager VERSION 0.21.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/x11/Environment.cpp
+++ b/src/environment/x11/Environment.cpp
@@ -111,6 +111,13 @@ namespace ymwm::environment {
       }
       break;
     }
+    case EnterNotify: {
+      if (NotifyNormal == event.xcrossing.mode and
+          NotifyInferior != event.xcrossing.detail) {
+        m_manager.focus().window(event.xcrossing.window);
+      }
+      break;
+    }
     case MapRequest: {
       XWindowAttributes wa;
       auto w = event.xmaprequest.window;

--- a/src/window/FocusManager.h
+++ b/src/window/FocusManager.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "Window.h"
+#include "environment/ID.h"
 
+#include <algorithm>
 #include <functional>
+#include <iterator>
 #include <optional>
 #include <vector>
 
@@ -68,6 +71,30 @@ namespace ymwm::window {
       return m_windows.empty() ? FocusedWindow{ std::nullopt }
                                : FocusedWindow{ const_cast<Window&>(
                                      m_windows.at(m_focused_window_index)) };
+    }
+
+    inline void window(environment::ID wid) noexcept {
+      if (m_windows.empty()) {
+        return;
+      }
+
+      auto found_window =
+          std::find_if(m_windows.cbegin(),
+                       m_windows.cend(),
+                       [wid](const auto& w) -> bool { return wid == w.id; });
+
+      if (m_windows.cend() == found_window) {
+        return;
+      }
+
+      update_index();
+
+      m_before_focus_move();
+
+      m_focused_window_index = std::distance(m_windows.cbegin(), found_window);
+      update();
+
+      m_after_focus_move();
     }
 
     inline void next_window() noexcept {

--- a/tests/window/WindowManagerTest.cpp
+++ b/tests/window/WindowManagerTest.cpp
@@ -501,3 +501,31 @@ TEST(TestWindowManager, SwapFocusedWindowWithTopOne) {
               .border_width = ymwm::config::windows::regular_border_width,
               .border_color = regular_color }));
 }
+
+TEST(TestWindowManager, TestFocusWindowById) {
+  ymwm::environment::TestEnvironment tenv;
+  ON_CALL(tenv, screen_width_and_height)
+      .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
+
+  ymwm::window::Manager m{ &tenv };
+  m.layout().update(ymwm::layouts::Maximised{});
+
+  m.add_window(ymwm::window::Window{ .id = 1 });
+  m.add_window(ymwm::window::Window{ .id = 2 });
+  m.add_window(ymwm::window::Window{ .id = 3 });
+
+  ASSERT_EQ(3ul, m.windows().size());
+  ASSERT_EQ(3, m.focus().window()->get().id);
+
+  EXPECT_CALL(tenv, update_window_border).Times(2);
+  EXPECT_CALL(tenv, focus_window).Times(1);
+
+  m.focus().window(2);
+  ASSERT_EQ(2, m.focus().window()->get().id);
+
+  EXPECT_CALL(tenv, update_window_border).Times(2);
+  EXPECT_CALL(tenv, focus_window).Times(1);
+
+  m.focus().window(1);
+  ASSERT_EQ(1, m.focus().window()->get().id);
+}


### PR DESCRIPTION
EnterNotify is sent to window in X11 environment when e.g. mouse is hovered upon window. In this case it is reasonable to focus window, which received this event.