### PR TITLE
Implement centered layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.22.1 LANGUAGES CXX)
+project(WindowManager VERSION 0.23.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/config/Layout.h
+++ b/src/config/Layout.h
@@ -42,4 +42,9 @@ namespace ymwm::config::layouts {
   namespace parallel {
     constinit inline MarginType margin{ 2 };
   }
+
+  namespace centered {
+    using WindowWidthRatioType = common::Ratio<50u, 100u>;
+    inline WindowWidthRatioType window_width_ratio{ 80 };
+  } // namespace centered
 } // namespace ymwm::config::layouts

--- a/src/layouts/CMakeLists.txt
+++ b/src/layouts/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(layouts OBJECT
+	${CMAKE_CURRENT_SOURCE_DIR}/Centered.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Maximized.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Grid.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/StackVerticalRight.cpp

--- a/src/layouts/Centered.cpp
+++ b/src/layouts/Centered.cpp
@@ -1,0 +1,48 @@
+#include "Centered.h"
+
+#include "Layout.h"
+#include "config/Layout.h"
+#include "window/Window.h"
+
+namespace ymwm::layouts {
+  Centered::Centered() noexcept = default;
+  Centered::Centered(config::layouts::Margin screen_margins,
+                     int screen_width,
+                     int screen_height) noexcept {
+    int width_without_margins =
+        screen_width - screen_margins.left - screen_margins.right;
+
+    window_w = width_without_margins *
+                   config::layouts::centered::window_width_ratio / 100 -
+               two_borders;
+
+    window_h = screen_height - screen_margins.top - screen_margins.bottom -
+               two_borders;
+    window_x = screen_margins.left *
+                   (config::layouts::centered::window_width_ratio / 100) +
+               width_without_margins *
+                   ((100 - config::layouts::centered::window_width_ratio) / 2) /
+                   100;
+    window_y = screen_margins.top;
+  }
+
+  template <>
+  void Layout::apply(const Centered& parameters, window::Window& w) noexcept {
+    const auto& [screen_width, screen_height, screen_margins, _] =
+        basic_parameters;
+
+    const auto& [_, window_w, window_h, window_x, window_y] = parameters;
+
+    w.w = window_w;
+    w.h = window_h;
+    w.x = window_x;
+    w.y = window_y;
+  }
+
+  template <>
+  void Layout::update(const Centered& parameters) noexcept {
+    this->parameters = Centered(this->basic_parameters.screen_margins,
+                                this->basic_parameters.screen_width,
+                                this->basic_parameters.screen_height);
+  }
+} // namespace ymwm::layouts

--- a/src/layouts/Centered.h
+++ b/src/layouts/Centered.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "config/Layout.h"
+#include "config/Window.h"
+
+namespace ymwm::layouts {
+  struct Centered {
+    static constexpr inline std::string_view type{ "Centered" };
+    int two_borders{ std::max(config::windows::regular_border_width,
+                              config::windows::focused_border_width) *
+                     2 };
+    int window_w{ 0 };
+    int window_h{ 0 };
+    int window_x{ 0 };
+    int window_y{ 0 };
+
+    Centered() noexcept;
+    Centered(config::layouts::Margin screen_margins,
+             int screen_width,
+             int screen_height) noexcept;
+  };
+
+} // namespace ymwm::layouts

--- a/src/layouts/Parameters.h
+++ b/src/layouts/Parameters.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Centered.h"
 #include "Grid.h"
 #include "Maximized.h"
 #include "ParallelHorizontal.h"
@@ -17,7 +18,8 @@
 
 namespace ymwm::layouts {
 
-  using Parameters = std::variant<Maximised,
+  using Parameters = std::variant<Centered,
+                                  Maximised,
                                   Grid,
                                   StackVerticalRight,
                                   StackVerticalLeft,

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -2,6 +2,7 @@
 #include "Window.h"
 #include "common/Ratio.h"
 #include "config/Layout.h"
+#include "layouts/Centered.h"
 #include "layouts/Layout.h"
 #include "layouts/Parameters.h"
 #include "layouts/StackHorizontalBottom.h"
@@ -70,6 +71,13 @@ namespace ymwm::window {
             cfg::MainWindowRatioType{ cfg::main_window_ratio + diff };
         update();
       };
+
+      if (std::holds_alternative<layouts::Centered>(m_layout_parameters)) {
+        namespace cfg = ymwm::config::layouts::centered;
+        cfg::window_width_ratio =
+            cfg::WindowWidthRatioType{ cfg::window_width_ratio + diff };
+        update();
+      }
     }
 
   private:


### PR DESCRIPTION
Centered layout is similar to Maximized, except that window is always centered on screen and its width can be changed in ratio of 50% to 100% percent, relative to screen.