### PR TITLE
Implement walking 4 directions in grid layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.24.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.25.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/common/Direction.h
+++ b/src/common/Direction.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace ymwm::common {
+  enum class Direction { Left, Right, Up, Down };
+}

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -2,6 +2,7 @@
 
 #include "CommandMacro.h"
 #include "common/Color.h"
+#include "common/Direction.h"
 
 #include <optional>
 #include <string>
@@ -28,6 +29,7 @@ namespace ymwm::environment::commands {
   DEFINE_COMMAND_WITH_PARAMS_1(IncreaseMainWindowRatio, int diff{ 10 });
   DEFINE_COMMAND_WITH_PARAMS_1(DecreaseMainWindowRatio, int diff{ 10 });
   DEFINE_COMMAND(SwapFocusedWindowOnTop)
+  DEFINE_COMMAND_WITH_PARAMS_1(MoveFocusOnGrid, common::Direction direction);
 
   using Command = std::variant<ExitRequested,
                                RunTerminal,
@@ -42,7 +44,8 @@ namespace ymwm::environment::commands {
                                SetLayout,
                                IncreaseMainWindowRatio,
                                DecreaseMainWindowRatio,
-                               SwapFocusedWindowOnTop>;
+                               SwapFocusedWindowOnTop,
+                               MoveFocusOnGrid>;
 
   template <std::size_t Index =
                 std::variant_size_v<environment::commands::Command> - 1ul>

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -1,5 +1,6 @@
 #include "environment/Command.h"
 #include "environment/Environment.h"
+#include "layouts/Grid.h"
 #include "layouts/Parameters.h"
 
 #include <cstdlib>
@@ -63,5 +64,14 @@ namespace ymwm::environment::commands {
 
   void SwapFocusedWindowOnTop::execute(Environment& e) const {
     e.manager().swap_focused_window_with_top();
+  }
+
+  void MoveFocusOnGrid::execute(Environment& e) const {
+    if (layouts::Grid::type == e.manager().layout().current()) {
+      auto&& parameters = e.manager().layout().parameters();
+      const auto& grid_parameters = std::get<layouts::Grid>(parameters);
+      e.manager().focus().move_on_grid(
+          direction, grid_parameters.grid_size, e.manager().windows().size());
+    }
   }
 } // namespace ymwm::environment::commands

--- a/src/events/Map.cpp
+++ b/src/events/Map.cpp
@@ -2,6 +2,7 @@
 
 #include "AbstractKeyCode.h"
 #include "AbstractKeyMask.h"
+#include "common/Direction.h"
 #include "environment/Command.h"
 #include "events/AbstractKeyPress.h"
 #include "layouts/Grid.h"
@@ -107,6 +108,37 @@ namespace ymwm::events {
             .code = ymwm::events::AbstractKeyCode::R,
             .mask = ymwm::events::AbstractKeyMask::Alt },
         ymwm::environment::commands::RunTerminal{ "/usr/bin/dmenu_run" });
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::J,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Ctrl },
+        ymwm::environment::commands::MoveFocusOnGrid{
+            common::Direction::Down });
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::K,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Ctrl },
+        ymwm::environment::commands::MoveFocusOnGrid{ common::Direction::Up });
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::H,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Ctrl },
+        ymwm::environment::commands::MoveFocusOnGrid{
+            common::Direction::Left });
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::L,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Ctrl },
+        ymwm::environment::commands::MoveFocusOnGrid{
+            common::Direction::Right });
 
     return bindings;
   }

--- a/src/window/FocusManager.h
+++ b/src/window/FocusManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Window.h"
+#include "common/Direction.h"
 #include "environment/ID.h"
 
 #include <algorithm>
@@ -142,12 +143,55 @@ namespace ymwm::window {
       return not m_windows.empty() and m_focused_window_index == 0ul;
     }
 
+    inline void move_on_grid(common::Direction direction,
+                             std::size_t grid_size,
+                             std::size_t number_of_windows) noexcept {
+      switch (direction) {
+      case common::Direction::Left:
+        if (0 != (m_focused_window_index % grid_size)) {
+          move_focus_to_index(m_focused_window_index - 1);
+        }
+        break;
+      case common::Direction::Right:
+        if ((grid_size - 1ul) != (m_focused_window_index % grid_size) and
+            number_of_windows > (m_focused_window_index + 1)) {
+          move_focus_to_index(m_focused_window_index + 1);
+        }
+        break;
+      case common::Direction::Up:
+        if (m_focused_window_index >= grid_size) {
+          move_focus_to_index(m_focused_window_index - grid_size);
+        }
+        break;
+      case common::Direction::Down:
+        if ((m_focused_window_index + grid_size) < number_of_windows) {
+          move_focus_to_index(m_focused_window_index + grid_size);
+        }
+        break;
+      }
+    }
+
   private:
     inline void update_index() noexcept {
       if (m_focused_window_index >= m_windows.size() and
           not m_windows.empty()) {
         m_focused_window_index = m_windows.size() - 1ul;
       }
+    }
+
+    inline void move_focus_to_index(std::size_t index) noexcept {
+      if (m_windows.empty()) {
+        return;
+      }
+
+      update_index();
+
+      m_before_focus_move();
+
+      m_focused_window_index = index;
+      update();
+
+      m_after_focus_move();
     }
 
   private:

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -8,6 +8,7 @@
 #include "layouts/StackHorizontalBottom.h"
 #include "layouts/StackHorizontalTop.h"
 
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -78,6 +79,17 @@ namespace ymwm::window {
             cfg::WindowWidthRatioType{ cfg::window_width_ratio + diff };
         update();
       }
+    }
+
+    inline std::string_view current() const noexcept {
+      return std::visit(
+          [](const auto& p) -> std::string_view { return p.type; },
+          m_layout_parameters);
+    }
+
+    inline layouts::Parameters parameters() noexcept {
+      auto layout = with_layout();
+      return layout.parameters;
     }
 
   private:

--- a/tests/window/WindowManagerTest.cpp
+++ b/tests/window/WindowManagerTest.cpp
@@ -1,7 +1,9 @@
 #include "TestEnvironment.h"
 #include "common/Color.h"
+#include "common/Direction.h"
 #include "config/Layout.h"
 #include "config/Window.h"
+#include "layouts/Grid.h"
 #include "layouts/Layout.h"
 #include "layouts/Parameters.h"
 #include "window/Manager.h"
@@ -10,6 +12,7 @@
 #include "gmock/gmock.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <variant>
 
 static const ymwm::common::Color regular_color =
     ymwm::config::windows::regular_border_color;
@@ -527,5 +530,103 @@ TEST(TestWindowManager, TestFocusWindowById) {
   EXPECT_CALL(tenv, focus_window).Times(1);
 
   m.focus().window(1);
+  ASSERT_EQ(1, m.focus().window()->get().id);
+}
+
+TEST(FocusManager, MoveFocusOnGrid) {
+  ymwm::environment::TestEnvironment tenv;
+  ON_CALL(tenv, screen_width_and_height)
+      .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
+
+  ymwm::window::Manager m{ &tenv };
+  m.layout().update(ymwm::layouts::Grid{});
+
+  m.add_window(ymwm::window::Window{ .id = 1 });
+  m.add_window(ymwm::window::Window{ .id = 2 });
+  m.add_window(ymwm::window::Window{ .id = 3 });
+  m.add_window(ymwm::window::Window{ .id = 4 });
+  m.add_window(ymwm::window::Window{ .id = 5 });
+
+  ASSERT_EQ(5, m.focus().window()->get().id);
+  ASSERT_EQ(5ul, m.windows().size());
+  auto params = m.layout().parameters();
+  ASSERT_TRUE(std::holds_alternative<ymwm::layouts::Grid>(params));
+  auto grid_params = std::get<ymwm::layouts::Grid>(params);
+  ASSERT_EQ(3ul, grid_params.grid_size);
+
+  m.focus().move_on_grid(ymwm::common::Direction::Left, 3ul, 5ul);
+  ASSERT_EQ(4, m.focus().window()->get().id);
+
+  // Verify repeated left move on left-most column has no effect.
+  m.focus().move_on_grid(ymwm::common::Direction::Left, 3ul, 5ul);
+  ASSERT_EQ(4, m.focus().window()->get().id);
+
+  m.focus().move_on_grid(ymwm::common::Direction::Right, 3ul, 5ul);
+  ASSERT_EQ(5, m.focus().window()->get().id);
+
+  // Verify repeated right move on right-most column has no effect.
+  m.focus().move_on_grid(ymwm::common::Direction::Right, 3ul, 5ul);
+  ASSERT_EQ(5, m.focus().window()->get().id);
+
+  m.focus().move_on_grid(ymwm::common::Direction::Up, 3ul, 5ul);
+  ASSERT_EQ(2, m.focus().window()->get().id);
+
+  // Verify repeated up move on top-most column has no effect.
+  m.focus().move_on_grid(ymwm::common::Direction::Up, 3ul, 5ul);
+  ASSERT_EQ(2, m.focus().window()->get().id);
+
+  m.focus().move_on_grid(ymwm::common::Direction::Right, 3ul, 5ul);
+  ASSERT_EQ(3, m.focus().window()->get().id);
+
+  // Verify down move has no effect, if grid is not filled completely.
+  m.focus().move_on_grid(ymwm::common::Direction::Down, 3ul, 5ul);
+  ASSERT_EQ(3, m.focus().window()->get().id);
+
+  m.focus().move_on_grid(ymwm::common::Direction::Left, 3ul, 5ul);
+  ASSERT_EQ(2, m.focus().window()->get().id);
+
+  m.focus().move_on_grid(ymwm::common::Direction::Down, 3ul, 5ul);
+  ASSERT_EQ(5, m.focus().window()->get().id);
+
+  // Verify repeated down move has no effect.
+  m.focus().move_on_grid(ymwm::common::Direction::Down, 3ul, 5ul);
+  ASSERT_EQ(5, m.focus().window()->get().id);
+
+  m.focus().move_on_grid(ymwm::common::Direction::Left, 3ul, 5ul);
+  ASSERT_EQ(4, m.focus().window()->get().id);
+
+  // Able to go up in left-most column.
+  m.focus().move_on_grid(ymwm::common::Direction::Up, 3ul, 5ul);
+  ASSERT_EQ(1, m.focus().window()->get().id);
+}
+
+TEST(FocusManager, MoveFocusOnGrid_OneWindowInGridOnly) {
+  ymwm::environment::TestEnvironment tenv;
+  ON_CALL(tenv, screen_width_and_height)
+      .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
+
+  ymwm::window::Manager m{ &tenv };
+  m.layout().update(ymwm::layouts::Grid{});
+
+  m.add_window(ymwm::window::Window{ .id = 1 });
+
+  ASSERT_EQ(1, m.focus().window()->get().id);
+  ASSERT_EQ(1ul, m.windows().size());
+  auto params = m.layout().parameters();
+  ASSERT_TRUE(std::holds_alternative<ymwm::layouts::Grid>(params));
+  auto grid_params = std::get<ymwm::layouts::Grid>(params);
+  ASSERT_EQ(2ul, grid_params.grid_size);
+
+  m.focus().move_on_grid(
+      ymwm::common::Direction::Left, grid_params.grid_size, 1ul);
+  ASSERT_EQ(1, m.focus().window()->get().id);
+  m.focus().move_on_grid(
+      ymwm::common::Direction::Right, grid_params.grid_size, 1ul);
+  ASSERT_EQ(1, m.focus().window()->get().id);
+  m.focus().move_on_grid(
+      ymwm::common::Direction::Up, grid_params.grid_size, 1ul);
+  ASSERT_EQ(1, m.focus().window()->get().id);
+  m.focus().move_on_grid(
+      ymwm::common::Direction::Down, grid_params.grid_size, 1ul);
   ASSERT_EQ(1, m.focus().window()->get().id);
 }


### PR DESCRIPTION
It makes much more sense to alter windows navigation specifically for Grid layout, enhancing user experience navigating between windows in 4 directions (Up, Down, Left, Right) instead of 2 only (Left and Right), as it reduces the amount of actions and time to reach the desired window significantly. 