### PR TITLE
Refactor focus manager

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,5 +1,6 @@
 command! -nargs=1 Init  :!cmake -S . -B <f-args> -DCMAKE_BUILD_TYPE=<f-args> -DCMAKE_INSTALL_PREFIX=<f-args> -DBUILD_TESTS=TRUE
 command! -nargs=1 Build :!cmake --build <f-args> --parallel && cmake --install <f-args>
+command! -nargs=1 InitBuild  :!cmake -S . -B <f-args> -DCMAKE_BUILD_TYPE=<f-args> -DCMAKE_INSTALL_PREFIX=<f-args> -DBUILD_TESTS=TRUE && cmake --build <f-args> --parallel && cmake --install <f-args> && ln -sf <f-args>/compile_commands.json .
 command! -nargs=1 Test  :!ctest --test-dir <f-args>/tests
 command! -nargs=1 TestV :!ctest --test-dir <f-args>/tests --verbose
 command! -nargs=1 Run :!./<f-args>/bin/WindowManager

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.25.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.26.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/window/FocusManager.h
+++ b/src/window/FocusManager.h
@@ -43,14 +43,7 @@ namespace ymwm::window {
         return;
       }
 
-      update_index();
-
-      m_before_focus_move();
-
-      m_focused_window_index = 0ul;
-      update();
-
-      m_after_focus_move();
+      update_index(0ul);
     }
 
     inline void last_window() noexcept {
@@ -58,14 +51,7 @@ namespace ymwm::window {
         return;
       }
 
-      update_index();
-
-      m_before_focus_move();
-
-      m_focused_window_index = m_windows.size() - 1ul;
-      update();
-
-      m_after_focus_move();
+      update_index(m_windows.size() - 1ul);
     }
 
     inline FocusedWindow window() const noexcept {
@@ -88,14 +74,7 @@ namespace ymwm::window {
         return;
       }
 
-      update_index();
-
-      m_before_focus_move();
-
-      m_focused_window_index = std::distance(m_windows.cbegin(), found_window);
-      update();
-
-      m_after_focus_move();
+      update_index(std::distance(m_windows.cbegin(), found_window));
     }
 
     inline void next_window() noexcept {
@@ -103,17 +82,9 @@ namespace ymwm::window {
         m_env->reset_focus();
         return;
       }
-      update_index();
-
-      m_before_focus_move();
-
-      m_focused_window_index =
-          m_focused_window_index >= (m_windows.size() - 1ul)
-              ? 0ul
-              : m_focused_window_index + 1ul;
-      update();
-
-      m_after_focus_move();
+      update_index(m_focused_window_index >= (m_windows.size() - 1ul)
+                       ? 0ul
+                       : m_focused_window_index + 1ul);
     }
 
     inline void prev_window() noexcept {
@@ -122,16 +93,9 @@ namespace ymwm::window {
         return;
       }
 
-      update_index();
-
-      m_before_focus_move();
-
-      m_focused_window_index = m_focused_window_index == 0ul
-                                   ? m_windows.size() - 1ul
-                                   : m_focused_window_index - 1ul;
-      update();
-
-      m_after_focus_move();
+      update_index(m_focused_window_index == 0ul
+                       ? m_windows.size() - 1ul
+                       : m_focused_window_index - 1ul);
     }
 
     inline bool is_last_window() const noexcept {
@@ -172,11 +136,22 @@ namespace ymwm::window {
     }
 
   private:
-    inline void update_index() noexcept {
+    inline void verify_index() noexcept {
       if (m_focused_window_index >= m_windows.size() and
           not m_windows.empty()) {
         m_focused_window_index = m_windows.size() - 1ul;
       }
+    }
+
+    inline void update_index(std::size_t new_index) noexcept {
+      verify_index();
+
+      m_before_focus_move();
+
+      m_focused_window_index = new_index;
+      update();
+
+      m_after_focus_move();
     }
 
     inline void move_focus_to_index(std::size_t index) noexcept {
@@ -184,14 +159,7 @@ namespace ymwm::window {
         return;
       }
 
-      update_index();
-
-      m_before_focus_move();
-
-      m_focused_window_index = index;
-      update();
-
-      m_after_focus_move();
+      update_index(index);
     }
 
   private:


### PR DESCRIPTION
There were several parts in FocusManager, which involved update of `focused_window_index` and calling `before/after_focus_update` callbacks. It is reasonable to utilize such code duplication in one method, which will be reusable in several places. 