### PR TITLE
Implement rotation of stack layouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.26.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.27.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -30,6 +30,7 @@ namespace ymwm::environment::commands {
   DEFINE_COMMAND_WITH_PARAMS_1(DecreaseMainWindowRatio, int diff{ 10 });
   DEFINE_COMMAND(SwapFocusedWindowOnTop)
   DEFINE_COMMAND_WITH_PARAMS_1(MoveFocusOnGrid, common::Direction direction);
+  DEFINE_COMMAND(RotateStackLayout)
 
   using Command = std::variant<ExitRequested,
                                RunTerminal,
@@ -45,7 +46,8 @@ namespace ymwm::environment::commands {
                                IncreaseMainWindowRatio,
                                DecreaseMainWindowRatio,
                                SwapFocusedWindowOnTop,
-                               MoveFocusOnGrid>;
+                               MoveFocusOnGrid,
+                               RotateStackLayout>;
 
   template <std::size_t Index =
                 std::variant_size_v<environment::commands::Command> - 1ul>

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -74,4 +74,8 @@ namespace ymwm::environment::commands {
           direction, grid_parameters.grid_size, e.manager().windows().size());
     }
   }
+
+  void RotateStackLayout::execute(Environment& e) const {
+    e.manager().layout().rotate();
+  }
 } // namespace ymwm::environment::commands

--- a/src/events/Map.cpp
+++ b/src/events/Map.cpp
@@ -140,6 +140,13 @@ namespace ymwm::events {
         ymwm::environment::commands::MoveFocusOnGrid{
             common::Direction::Right });
 
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::R,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Shift },
+        ymwm::environment::commands::RotateStackLayout{});
+
     return bindings;
   }
 

--- a/src/window/LayoutManager.h
+++ b/src/window/LayoutManager.h
@@ -92,6 +92,11 @@ namespace ymwm::window {
       return layout.parameters;
     }
 
+    inline void rotate() noexcept {
+      m_layout_parameters = rotated_parameters();
+      update();
+    }
+
   private:
     inline layouts::Layout with_layout() noexcept {
       auto [screen_width, screen_height] = m_env->screen_width_and_height();
@@ -109,6 +114,35 @@ namespace ymwm::window {
       // Do any specific layout paramters update
       layout.update(m_basic_layout_parameters, m_layout_parameters);
       return layout;
+    }
+
+    inline layouts::Parameters rotated_parameters() const noexcept {
+      if (std::holds_alternative<layouts::StackVerticalRight>(
+              m_layout_parameters)) {
+        return layouts::StackHorizontalTop{};
+      }
+      if (std::holds_alternative<layouts::StackVerticalLeft>(
+              m_layout_parameters)) {
+        return layouts::StackHorizontalBottom{};
+      }
+      if (std::holds_alternative<layouts::StackVerticalDouble>(
+              m_layout_parameters)) {
+        return layouts::StackHorizontalDouble{};
+      }
+      if (std::holds_alternative<layouts::StackHorizontalTop>(
+              m_layout_parameters)) {
+        return layouts::StackVerticalLeft{};
+      }
+      if (std::holds_alternative<layouts::StackHorizontalBottom>(
+              m_layout_parameters)) {
+        return layouts::StackVerticalRight{};
+      }
+      if (std::holds_alternative<layouts::StackHorizontalDouble>(
+              m_layout_parameters)) {
+        return layouts::StackVerticalDouble{};
+      }
+
+      return m_layout_parameters;
     }
 
   private:

--- a/tests/window/WindowManagerTest.cpp
+++ b/tests/window/WindowManagerTest.cpp
@@ -6,6 +6,7 @@
 #include "layouts/Grid.h"
 #include "layouts/Layout.h"
 #include "layouts/Parameters.h"
+#include "layouts/StackHorizontalBottom.h"
 #include "window/Manager.h"
 #include "window/Window.h"
 
@@ -629,4 +630,59 @@ TEST(FocusManager, MoveFocusOnGrid_OneWindowInGridOnly) {
   m.focus().move_on_grid(
       ymwm::common::Direction::Down, grid_params.grid_size, 1ul);
   ASSERT_EQ(1, m.focus().window()->get().id);
+}
+
+TEST(TestLayoutManager, TestRotateStackLayout) {
+  ymwm::environment::TestEnvironment tenv;
+  ON_CALL(tenv, screen_width_and_height)
+      .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
+
+  ymwm::window::Manager m{ &tenv };
+  m.layout().update(ymwm::layouts::StackVerticalRight{});
+
+  auto params = m.layout().parameters();
+  ASSERT_TRUE(
+      std::holds_alternative<ymwm::layouts::StackVerticalRight>(params));
+
+  for (auto contains_expected_parameters : std::initializer_list<
+           std::function<bool(const ymwm::layouts::Parameters&)>>{
+           [](const ymwm::layouts::Parameters& p) -> bool {
+             return std::holds_alternative<ymwm::layouts::StackHorizontalTop>(
+                 p);
+           },
+           [](const ymwm::layouts::Parameters& p) -> bool {
+             return std::holds_alternative<ymwm::layouts::StackVerticalLeft>(p);
+           },
+           [](const ymwm::layouts::Parameters& p) -> bool {
+             return std::holds_alternative<
+                 ymwm::layouts::StackHorizontalBottom>(p);
+           },
+           [](const ymwm::layouts::Parameters& p) -> bool {
+             return std::holds_alternative<ymwm::layouts::StackVerticalRight>(
+                 p);
+           } }) {
+    m.layout().rotate();
+    params = m.layout().parameters();
+    ASSERT_TRUE(contains_expected_parameters(params));
+  }
+
+  m.layout().update(ymwm::layouts::StackVerticalDouble{});
+  params = m.layout().parameters();
+  ASSERT_TRUE(
+      std::holds_alternative<ymwm::layouts::StackVerticalDouble>(params));
+
+  for (auto contains_expected_parameters : std::initializer_list<
+           std::function<bool(const ymwm::layouts::Parameters&)>>{
+           [](const ymwm::layouts::Parameters& p) -> bool {
+             return std::holds_alternative<
+                 ymwm::layouts::StackHorizontalDouble>(p);
+           },
+           [](const ymwm::layouts::Parameters& p) -> bool {
+             return std::holds_alternative<ymwm::layouts::StackVerticalDouble>(
+                 p);
+           } }) {
+    m.layout().rotate();
+    params = m.layout().parameters();
+    ASSERT_TRUE(contains_expected_parameters(params));
+  }
 }


### PR DESCRIPTION
It may be useful for some users to rotate stack layout, rearranging windows in different stack direction, in case they are not satisfied with current way of things placed. This allows to reach desired stack layout quicker then walking through the list of all known layouts.