### PR TITLE
Translate environment specific events through abstract event loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.29.1 LANGUAGES CXX)
+project(WindowManager VERSION 0.30.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -3,6 +3,7 @@
 #include "CommandMacro.h"
 #include "common/Color.h"
 #include "common/Direction.h"
+#include "environment/ID.h"
 
 #include <optional>
 #include <string>
@@ -32,6 +33,10 @@ namespace ymwm::environment::commands {
   DEFINE_COMMAND_WITH_PARAMS_1(MoveFocusOnGrid, common::Direction direction);
   DEFINE_COMMAND(RotateStackLayout)
   DEFINE_COMMAND(NextLanguageLayout);
+  DEFINE_COMMAND(AddWindow);
+  DEFINE_COMMAND(UpdateWindowName);
+  DEFINE_COMMAND_WITH_PARAMS_1(FocusWindow, environment::ID wid);
+  DEFINE_COMMAND_WITH_PARAMS_1(RemoveWindow, environment::ID wid);
 
   using Command = std::variant<ExitRequested,
                                RunTerminal,
@@ -49,7 +54,11 @@ namespace ymwm::environment::commands {
                                SwapFocusedWindowOnTop,
                                MoveFocusOnGrid,
                                RotateStackLayout,
-                               NextLanguageLayout>;
+                               NextLanguageLayout,
+                               AddWindow,
+                               UpdateWindowName,
+                               FocusWindow,
+                               RemoveWindow>;
 
   template <std::size_t Index =
                 std::variant_size_v<environment::commands::Command> - 1ul>

--- a/src/environment/CommandMacro.h
+++ b/src/environment/CommandMacro.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <events/Event.h>
 #include <string_view>
 
 #define DEFINE_MEMBER(x) x;
@@ -7,7 +8,8 @@
   struct name {                                                                \
     static inline constexpr std::string_view type{ #name };                    \
     inline constexpr auto operator<=>(const name&) const noexcept = default;   \
-    void execute([[maybe_unused]] Environment&) const;
+    void execute([[maybe_unused]] Environment&,                                \
+                 [[maybe_unused]] const events::Event&) const;
 
 // clang-format off
 #define END_DEFINE_COMMAND };

--- a/src/environment/Environment.cpp
+++ b/src/environment/Environment.cpp
@@ -1,11 +1,15 @@
 #include "Environment.h"
 
+#include "events/Event.h"
+
 #include <variant>
 
 namespace ymwm::environment {
 
-  void Environment::execute(const commands::Command& cmd) {
-    std::visit([env = this](const auto& c) { c.execute(*env); }, cmd);
+  void Environment::execute(const commands::Command& cmd,
+                            const events::Event& event) {
+    std::visit([env = this, &event](const auto& c) { c.execute(*env, event); },
+               cmd);
   }
 
   bool Environment::exit_requested() const noexcept { return m_exit_requested; }

--- a/src/environment/Environment.h
+++ b/src/environment/Environment.h
@@ -18,7 +18,8 @@ namespace ymwm::environment {
     ~Environment();
 
     events::Event event() const noexcept;
-    void execute(const commands::Command& cmd);
+    void execute(const commands::Command& cmd,
+                 [[maybe_unused]] const events::Event& event);
     bool exit_requested() const noexcept;
     void request_exit() noexcept;
     Handlers& handlers() noexcept;

--- a/src/environment/x11/XClientKeyGrabber.h
+++ b/src/environment/x11/XClientKeyGrabber.h
@@ -9,9 +9,7 @@ namespace ymwm::environment {
     Handlers* handlers;
 
     template <typename EventType>
-    inline void operator()(const EventType& event) {
-      std::cerr << "Unexpected event type: " << event.type << "\n";
-    }
+    inline void operator()(const EventType& event) {}
 
     template <>
     inline void operator()(const events::AbstractKeyPress& event) {

--- a/src/events/Event.h
+++ b/src/events/Event.h
@@ -3,10 +3,19 @@
 #include "AbstractKeyPress.h"
 #include "AbstractMousePress.h"
 #include "AbstractUnknownEvent.h"
+#include "MouseOverWindow.h"
+#include "WindowAdded.h"
+#include "WindowNameUpdated.h"
+#include "WindowRemoved.h"
 
 #include <variant>
 
 namespace ymwm::events {
-  using Event =
-      std::variant<AbstractKeyPress, AbstractMousePress, AbstractUnknownEvent>;
+  using Event = std::variant<AbstractKeyPress,
+                             AbstractMousePress,
+                             AbstractUnknownEvent,
+                             WindowAdded,
+                             WindowNameUpdated,
+                             MouseOverWindow,
+                             WindowRemoved>;
 }

--- a/src/events/Hash.h
+++ b/src/events/Hash.h
@@ -19,6 +19,22 @@ namespace ymwm::events {
     inline std::size_t operator()(const AbstractUnknownEvent&) const noexcept {
       return 0u;
     }
+
+    inline std::size_t operator()(const WindowAdded& e) const noexcept {
+      return std::hash<std::string_view>{}(e.type);
+    }
+
+    inline std::size_t operator()(const WindowRemoved& e) const noexcept {
+      return std::hash<std::string_view>{}(e.type);
+    }
+
+    inline std::size_t operator()(const WindowNameUpdated& e) const noexcept {
+      return std::hash<std::string_view>{}(e.type);
+    }
+
+    inline std::size_t operator()(const MouseOverWindow& e) const noexcept {
+      return std::hash<std::string_view>{}(e.type);
+    }
   };
 
   struct Hasher {

--- a/src/events/Map.cpp
+++ b/src/events/Map.cpp
@@ -5,6 +5,10 @@
 #include "common/Direction.h"
 #include "environment/Command.h"
 #include "events/AbstractKeyPress.h"
+#include "events/MouseOverWindow.h"
+#include "events/WindowAdded.h"
+#include "events/WindowNameUpdated.h"
+#include "events/WindowRemoved.h"
 #include "layouts/Grid.h"
 #include "layouts/Maximized.h"
 #include "layouts/StackVerticalDouble.h"
@@ -12,6 +16,18 @@
 namespace ymwm::events {
   Map default_event_map() noexcept {
     Map bindings;
+
+    bindings.emplace(ymwm::events::WindowAdded{},
+                     ymwm::environment::commands::AddWindow{});
+
+    bindings.emplace(ymwm::events::WindowRemoved{},
+                     ymwm::environment::commands::RemoveWindow{});
+
+    bindings.emplace(ymwm::events::WindowNameUpdated{},
+                     ymwm::environment::commands::UpdateWindowName{});
+
+    bindings.emplace(ymwm::events::MouseOverWindow{},
+                     ymwm::environment::commands::FocusWindow{});
 
     bindings.emplace(
         ymwm::events::AbstractKeyPress{

--- a/src/events/MouseOverWindow.h
+++ b/src/events/MouseOverWindow.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "environment/ID.h"
+
+#include <string>
+namespace ymwm::events {
+  struct MouseOverWindow {
+    environment::ID wid;
+
+    constexpr bool operator==(const MouseOverWindow&) const noexcept {
+      return true;
+    }
+    static inline constexpr std::string_view type{ "MouseOverWindow" };
+  };
+} // namespace ymwm::events

--- a/src/events/WindowAdded.h
+++ b/src/events/WindowAdded.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "window/Window.h"
+
+namespace ymwm::events {
+  struct WindowAdded {
+    window::Window w;
+
+    constexpr bool operator==(const WindowAdded&) const noexcept {
+      return true;
+    }
+    static inline constexpr std::string_view type{ "WindowAdded" };
+  };
+} // namespace ymwm::events

--- a/src/events/WindowNameUpdated.h
+++ b/src/events/WindowNameUpdated.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "environment/ID.h"
+
+#include <string>
+namespace ymwm::events {
+  struct WindowNameUpdated {
+    environment::ID wid;
+    std::u8string wname;
+
+    constexpr bool operator==(const WindowNameUpdated&) const noexcept {
+      return true;
+    }
+    static inline constexpr std::string_view type{ "WindowNameUpdated" };
+  };
+} // namespace ymwm::events

--- a/src/events/WindowRemoved.h
+++ b/src/events/WindowRemoved.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "environment/ID.h"
+
+#include <string_view>
+
+namespace ymwm::events {
+  struct WindowRemoved {
+    environment::ID wid;
+
+    constexpr bool operator==(const WindowRemoved&) const noexcept {
+      return true;
+    }
+    static inline constexpr std::string_view type{ "WindowRemoved" };
+  };
+} // namespace ymwm::events

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
     if (not events_map.contains(event)) {
       continue;
     }
-    env.execute(events_map.at(event));
+    env.execute(events_map.at(event), event);
   }
 
   return 0;


### PR DESCRIPTION
Events like `WindowAdded`, `WindowRemoved`, `WindowNameUpdated`, `MouseOverWindow` must be translated to the level of main abstraction event loop as well as `AbstractKeyPress`, so that abstraction level could be more in-touch with platform-specific level. 