### PR TITLE
Don't focus window on Centered layout for mouse move

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.33.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.34.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -107,7 +107,9 @@ namespace ymwm::environment::commands {
   }
 
   void FocusWindow::execute(Environment& e, const events::Event& event) const {
-    if (const auto* ev = std::get_if<events::MouseOverWindow>(&event)) {
+    if (const auto* ev = std::get_if<events::MouseOverWindow>(&event);
+        ev and
+        not layouts::is<layouts::Centered>(e.manager().layout().parameters())) {
       e.manager().focus().window(ev->wid);
     }
   }

--- a/src/window/FocusManager.h
+++ b/src/window/FocusManager.h
@@ -65,6 +65,10 @@ namespace ymwm::window {
         return;
       }
 
+      if (auto w = window(); w.has_value() and wid == w->get().id) {
+        return;
+      }
+
       auto found_window =
           std::find_if(m_windows.cbegin(),
                        m_windows.cend(),

--- a/tests/window/WindowManagerTest.cpp
+++ b/tests/window/WindowManagerTest.cpp
@@ -686,3 +686,35 @@ TEST(TestLayoutManager, TestRotateStackLayout) {
     ASSERT_TRUE(contains_expected_parameters(params));
   }
 }
+
+TEST(TestFocusManager, DontFocusSameWindowTwice) {
+  ymwm::environment::TestEnvironment tenv;
+  ON_CALL(tenv, screen_width_and_height)
+      .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
+
+  ymwm::window::Manager m{ &tenv };
+
+  m.add_window(ymwm::window::Window{ .id = 1 });
+
+  ASSERT_EQ(1, m.focus().window()->get().id);
+  ASSERT_EQ(1ul, m.windows().size());
+  ASSERT_TRUE(m.focus().window());
+  ASSERT_EQ(1, m.focus().window()->get().id);
+
+  EXPECT_CALL(tenv, focus_window).Times(0);
+  m.focus().window(1);
+}
+
+TEST(TestFocusManager, DontFocusNonExistingWindow) {
+  ymwm::environment::TestEnvironment tenv;
+  ON_CALL(tenv, screen_width_and_height)
+      .WillByDefault(testing::Return(std::make_tuple(1000, 1000)));
+
+  ymwm::window::Manager m{ &tenv };
+
+  ASSERT_TRUE(m.windows().empty());
+  ASSERT_FALSE(m.focus().window().has_value());
+
+  EXPECT_CALL(tenv, focus_window).Times(0);
+  m.focus().window(1);
+}


### PR DESCRIPTION
There is a bug with certain windows, that may disappear upon start and create new window afterwards in matter of milliseconds. This triggers focus of added window + focus by EnterWindow event (cursor points on window immediately), which results in disgusting screen flickering. 
There is no need to react on EnterWindow event when layout is Centered and focus the same window multiple times in a row.