### PR TITLE
Fix update focus index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.35.1 LANGUAGES CXX)
+project(WindowManager VERSION 0.35.2 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/window/FocusManager.h
+++ b/src/window/FocusManager.h
@@ -153,6 +153,7 @@ namespace ymwm::window {
       m_before_focus_move();
 
       m_focused_window_index = new_index;
+      verify_index();
       update();
 
       m_after_focus_move();


### PR DESCRIPTION
`pavucontrol` window closing resulted in recent segfault. Turns out there were no check for new value for focused window index, so the `verify_index()` call added before update() call and after assigning new value to focused window index.