### PR TITLE
Implement groups abstraction and management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.36.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.37.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/config/utils.h
+++ b/src/config/utils.h
@@ -43,6 +43,8 @@ namespace ymwm::config::utils {
         { "Backspace", events::AbstractKeyCode::Backspace },
         {     "Space",     events::AbstractKeyCode::Space },
         {         "~",   events::AbstractKeyCode::Titulus },
+        {         ".",    events::AbstractKeyCode::Period },
+        {         ",",     events::AbstractKeyCode::Comma },
   };
 
   static inline std::optional<unsigned int>

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -37,6 +37,9 @@ namespace ymwm::environment::commands {
   DEFINE_COMMAND(UpdateWindowName);
   DEFINE_COMMAND_WITH_PARAMS_1(FocusWindow, environment::ID wid);
   DEFINE_COMMAND_WITH_PARAMS_1(RemoveWindow, environment::ID wid);
+  DEFINE_COMMAND(AddGroup);
+  DEFINE_COMMAND(MoveToNextGroup);
+  DEFINE_COMMAND(MoveToPrevGroup);
 
   using Command = std::variant<ExitRequested,
                                RunTerminal,
@@ -58,7 +61,10 @@ namespace ymwm::environment::commands {
                                AddWindow,
                                UpdateWindowName,
                                FocusWindow,
-                               RemoveWindow>;
+                               RemoveWindow,
+                               AddGroup,
+                               MoveToNextGroup,
+                               MoveToPrevGroup>;
 
   template <std::size_t Index =
                 std::variant_size_v<environment::commands::Command> - 1ul>

--- a/src/environment/Environment.cpp
+++ b/src/environment/Environment.cpp
@@ -17,6 +17,10 @@ namespace ymwm::environment {
   void Environment::request_exit() noexcept { m_exit_requested = true; }
 
   ymwm::window::Manager<Environment>& Environment::manager() noexcept {
-    return m_manager;
+    return m_group_manager.manager();
+  }
+
+  ymwm::window::GroupManager<Environment>& Environment::group() noexcept {
+    return m_group_manager;
   }
 } // namespace ymwm::environment

--- a/src/environment/Environment.h
+++ b/src/environment/Environment.h
@@ -3,7 +3,7 @@
 #include "Command.h"
 #include "events/Event.h"
 #include "events/Map.h"
-#include "window/Manager.h"
+#include "window/GroupManager.h"
 
 #include <memory>
 #include <tuple>
@@ -31,12 +31,13 @@ namespace ymwm::environment {
     void move_and_resize(const window::Window& w) noexcept;
     void close_window(const window::Window& w) noexcept;
     ymwm::window::Manager<Environment>& manager() noexcept;
+    ymwm::window::GroupManager<Environment>& group() noexcept;
     std::tuple<int, int> screen_width_and_height() noexcept;
     void next_keyboard_layout() noexcept;
 
   private:
     std::unique_ptr<Handlers> m_handlers;
     bool m_exit_requested;
-    mutable ymwm::window::Manager<Environment> m_manager;
+    ymwm::window::GroupManager<Environment> m_group_manager;
   };
 } // namespace ymwm::environment

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -119,4 +119,18 @@ namespace ymwm::environment::commands {
       e.manager().remove_window(ev->wid);
     }
   }
+
+  void AddGroup::execute(Environment& e, const events::Event& event) const {
+    e.group().add();
+  }
+
+  void MoveToNextGroup::execute(Environment& e,
+                                const events::Event& event) const {
+    e.group().next();
+  }
+
+  void MoveToPrevGroup::execute(Environment& e,
+                                const events::Event& event) const {
+    e.group().prev();
+  }
 } // namespace ymwm::environment::commands

--- a/src/environment/x11/Environment.cpp
+++ b/src/environment/x11/Environment.cpp
@@ -31,7 +31,7 @@ namespace ymwm::environment {
 namespace ymwm::environment {
   Environment::Environment(const events::Map& events_map)
       : m_exit_requested(false)
-      , m_manager(this) {
+      , m_group_manager(this) {
 
     // Bind error handler
     XSetErrorHandler(handle_x_error);

--- a/src/events/AbstractKeyCode.h
+++ b/src/events/AbstractKeyCode.h
@@ -36,5 +36,7 @@ namespace ymwm::events {
     static Type Space;
     static Type Titulus;
     static Type Backspace;
+    static Type Period;
+    static Type Comma;
   };
 } // namespace ymwm::events

--- a/src/events/Map.cpp
+++ b/src/events/Map.cpp
@@ -179,6 +179,25 @@ namespace ymwm::events {
             .mask = ymwm::events::AbstractKeyMask::Alt },
         ymwm::environment::commands::NextLanguageLayout{});
 
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::N,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Ctrl },
+        ymwm::environment::commands::AddGroup{});
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::Period,
+            .mask = ymwm::events::AbstractKeyMask::Alt },
+        ymwm::environment::commands::MoveToNextGroup{});
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::Comma,
+            .mask = ymwm::events::AbstractKeyMask::Alt },
+        ymwm::environment::commands::MoveToPrevGroup{});
+
     return bindings;
   }
 

--- a/src/events/x11/KeyCodes.cpp
+++ b/src/events/x11/KeyCodes.cpp
@@ -33,4 +33,7 @@ namespace ymwm::events {
   AbstractKeyCode::Type AbstractKeyCode::Space{ XK_space };
   AbstractKeyCode::Type AbstractKeyCode::Titulus{ XK_grave };
   AbstractKeyCode::Type AbstractKeyCode::Backspace{ XK_BackSpace };
+  AbstractKeyCode::Type AbstractKeyCode::Period{ XK_period };
+  AbstractKeyCode::Type AbstractKeyCode::Comma{ XK_comma };
+
 } // namespace ymwm::events

--- a/src/window/GroupManager.h
+++ b/src/window/GroupManager.h
@@ -22,20 +22,6 @@ namespace ymwm::window {
       m_managers.emplace_back(m_env);
       next();
     }
-    // inline void remove() noexcept {
-    // if (one_manager_present()) {
-    // return;
-    // }
-
-    // manager().deactivate();
-
-    // m_managers.erase(std::next(m_managers.begin(), m_active_manager));
-    // if (not is_first_active()) {
-    // --m_active_manager;
-    // }
-
-    // manager().activate();
-    // }
 
     inline void next() noexcept {
       if (one_manager_present()) {

--- a/src/window/GroupManager.h
+++ b/src/window/GroupManager.h
@@ -1,0 +1,98 @@
+#pragma once
+#include "Manager.h"
+
+#include <vector>
+
+namespace ymwm::window {
+
+  template <typename Environment>
+  struct GroupManager {
+    inline GroupManager(Environment* env)
+        : m_env(env)
+        , m_active_manager(0ul) {
+      m_managers.reserve(4);
+      m_managers.emplace_back(m_env);
+    }
+
+    inline Manager<Environment>& manager() noexcept {
+      return m_managers.at(m_active_manager);
+    }
+
+    inline void add() noexcept {
+      m_managers.emplace_back(m_env);
+      next();
+    }
+    // inline void remove() noexcept {
+    // if (one_manager_present()) {
+    // return;
+    // }
+
+    // manager().deactivate();
+
+    // m_managers.erase(std::next(m_managers.begin(), m_active_manager));
+    // if (not is_first_active()) {
+    // --m_active_manager;
+    // }
+
+    // manager().activate();
+    // }
+
+    inline void next() noexcept {
+      if (one_manager_present()) {
+        return;
+      }
+
+      manager().deactivate();
+
+      m_active_manager = is_last_active() ? 0ul : m_active_manager + 1ul;
+
+      manager().activate();
+    }
+
+    inline void prev() noexcept {
+      if (one_manager_present()) {
+        return;
+      }
+
+      manager().deactivate();
+
+      m_active_manager =
+          is_first_active() ? m_managers.size() - 1ul : m_active_manager - 1ul;
+
+      manager().activate();
+    }
+
+    inline void activate(std::size_t manager_index) noexcept {
+      if (not valid_index(manager_index)) {
+        return;
+      }
+
+      manager().deactivate();
+      m_active_manager = manager_index;
+      manager().activate();
+    }
+
+    inline ~GroupManager() = default;
+
+  private:
+    inline bool valid_index(std::size_t manager_index) noexcept {
+      return manager_index < m_managers.size();
+    }
+
+    inline bool one_manager_present() const noexcept {
+      return 1ul == m_managers.size();
+    }
+
+    inline bool is_first_active() const noexcept {
+      return 0ul == m_active_manager;
+    }
+
+    inline bool is_last_active() const noexcept {
+      return (m_managers.size() - 1ul) == m_active_manager;
+    }
+
+    Environment* const m_env;
+    std::size_t m_active_manager;
+    std::vector<Manager<Environment>> m_managers;
+  };
+} // namespace ymwm::window

--- a/src/window/Manager.h
+++ b/src/window/Manager.h
@@ -133,6 +133,18 @@ namespace ymwm::window {
       focus().first_window();
     }
 
+    inline void activate() noexcept {
+      layout().update();
+      focus().update();
+    }
+
+    inline void deactivate() noexcept {
+      for (auto& w : m_windows) {
+        w.x = 0 - w.w * 2;
+        m_env->move_and_resize(w);
+      }
+    }
+
     inline FocusManager<Environment>& focus() noexcept {
       return m_focus_manager;
     }


### PR DESCRIPTION
`Group` abstraction represents group of windows with certain layout applied. 
Each `Group` has it's own layout, though it is not obliged to have unique one.
User can add `Group` on demand and move between groups. 
Removal of `Group`s is currently hard to implement, certain adjustments to data structure holding windows and managers is needed, thus it is not implemented in this PR.