### PR TITLE
Fix segfault on main without x11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.37.6 LANGUAGES CXX)
+project(WindowManager VERSION 0.37.7 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,9 @@ int main(int argc, char** argv) {
   auto events_map = parse_config(std::move(parsed_args.config_path));
 
   ymwm::environment::Environment env{ events_map };
+  if (env.exit_requested()) {
+    return 1;
+  }
 
   for (auto event = env.event(); not env.exit_requested();
        event = env.event()) {


### PR DESCRIPTION
In case WindowManager was started without X11, segfault occured due to attempt of requesting XEvent from X11. Early return applied, in case exit requested after Environment initialisation.