### PR TITLE
Decrease centered layout window ratio minimal limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.37.7 LANGUAGES CXX)
+project(WindowManager VERSION 0.37.8 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/config/Layout.h
+++ b/src/config/Layout.h
@@ -44,7 +44,7 @@ namespace ymwm::config::layouts {
   }
 
   namespace centered {
-    using WindowWidthRatioType = common::Ratio<50u, 100u>;
+    using WindowWidthRatioType = common::Ratio<20u, 100u>;
     inline WindowWidthRatioType window_width_ratio{ 100 };
   } // namespace centered
 } // namespace ymwm::config::layouts


### PR DESCRIPTION
Setting minimal value of Centered window ratio to 20% extends ability of devs, especially web designers to play with window width while testing UI responsiveness.