### PR TITLE
Implement group removal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.38.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.39.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/config/utils.h
+++ b/src/config/utils.h
@@ -43,6 +43,7 @@ namespace ymwm::config::utils {
         {     "Enter",     events::AbstractKeyCode::Enter },
         { "Backspace", events::AbstractKeyCode::Backspace },
         {     "Space",     events::AbstractKeyCode::Space },
+        {       "Del",       events::AbstractKeyCode::Del },
         {         "~",   events::AbstractKeyCode::Titulus },
         {         ".",    events::AbstractKeyCode::Period },
         {         ",",     events::AbstractKeyCode::Comma },

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -40,6 +40,7 @@ namespace ymwm::environment::commands {
   DEFINE_COMMAND(AddGroup);
   DEFINE_COMMAND(MoveToNextGroup);
   DEFINE_COMMAND(MoveToPrevGroup);
+  DEFINE_COMMAND(RemoveGroup);
 
   using Command = std::variant<ExitRequested,
                                RunTerminal,
@@ -64,6 +65,7 @@ namespace ymwm::environment::commands {
                                RemoveWindow,
                                AddGroup,
                                MoveToNextGroup,
-                               MoveToPrevGroup>;
+                               MoveToPrevGroup,
+                               RemoveGroup>;
 
 } // namespace ymwm::environment::commands

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -120,6 +120,9 @@ namespace ymwm::environment::commands {
   void RemoveWindow::execute(Environment& e, const events::Event& event) const {
     if (const auto* ev = std::get_if<events::WindowRemoved>(&event)) {
       e.manager().remove_window(ev->wid);
+      if (e.manager().windows().empty()) {
+        e.group().remove(e.group().active());
+      }
     }
   }
 

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -139,4 +139,8 @@ namespace ymwm::environment::commands {
                                 const events::Event& event) const {
     e.group().prev();
   }
+
+  void RemoveGroup::execute(Environment& e, const events::Event& event) const {
+    e.group().remove(e.group().active());
+  }
 } // namespace ymwm::environment::commands

--- a/src/events/AbstractKeyCode.h
+++ b/src/events/AbstractKeyCode.h
@@ -38,5 +38,6 @@ namespace ymwm::events {
     static Type Backspace;
     static Type Period;
     static Type Comma;
+    static Type Del;
   };
 } // namespace ymwm::events

--- a/src/events/Map.cpp
+++ b/src/events/Map.cpp
@@ -198,6 +198,13 @@ namespace ymwm::events {
             .mask = ymwm::events::AbstractKeyMask::Alt },
         ymwm::environment::commands::MoveToPrevGroup{});
 
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::Del,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Ctrl },
+        ymwm::environment::commands::RemoveGroup{});
+
     return bindings;
   }
 

--- a/src/events/x11/KeyCodes.cpp
+++ b/src/events/x11/KeyCodes.cpp
@@ -35,5 +35,6 @@ namespace ymwm::events {
   AbstractKeyCode::Type AbstractKeyCode::Backspace{ XK_BackSpace };
   AbstractKeyCode::Type AbstractKeyCode::Period{ XK_period };
   AbstractKeyCode::Type AbstractKeyCode::Comma{ XK_comma };
+  AbstractKeyCode::Type AbstractKeyCode::Del{ XK_Delete };
 
 } // namespace ymwm::events

--- a/src/window/GroupManager.h
+++ b/src/window/GroupManager.h
@@ -58,20 +58,25 @@ namespace ymwm::window {
     }
 
     inline void remove(std::size_t manager_index) noexcept {
-      if (not valid_index(manager_index)) {
+      if (not valid_index(manager_index) or one_manager_present()) {
         return;
       }
 
-      if (m_active_manager == manager_index) {
+      if (m_active_manager == manager_index and m_active_manager > 0ul) {
+        activate(m_active_manager - 1ul);
+        m_managers.erase(std::next(m_managers.begin(), manager_index));
+        return;
+      }
+
+      if (m_active_manager == manager_index and m_active_manager == 0ul) {
         manager().deactivate();
-        m_active_manager = manager_index;
-        manager().activate();
+        m_managers.erase(std::next(m_managers.begin(), manager_index));
+        activate(m_active_manager);
         return;
-      }
-
-      if (m_active_manager < manager_index) {
       }
     }
+
+    inline std::size_t active() const noexcept { return m_active_manager; }
 
     inline ~GroupManager() = default;
 

--- a/src/window/GroupManager.h
+++ b/src/window/GroupManager.h
@@ -74,6 +74,11 @@ namespace ymwm::window {
         activate(m_active_manager);
         return;
       }
+
+      if (m_active_manager > manager_index) {
+        --m_active_manager;
+      }
+      m_managers.erase(std::next(m_managers.begin(), manager_index));
     }
 
     inline std::size_t active() const noexcept { return m_active_manager; }

--- a/src/window/GroupManager.h
+++ b/src/window/GroupManager.h
@@ -57,6 +57,22 @@ namespace ymwm::window {
       manager().activate();
     }
 
+    inline void remove(std::size_t manager_index) noexcept {
+      if (not valid_index(manager_index)) {
+        return;
+      }
+
+      if (m_active_manager == manager_index) {
+        manager().deactivate();
+        m_active_manager = manager_index;
+        manager().activate();
+        return;
+      }
+
+      if (m_active_manager < manager_index) {
+      }
+    }
+
     inline ~GroupManager() = default;
 
   private:

--- a/src/window/GroupManager.h
+++ b/src/window/GroupManager.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Manager.h"
 
-#include <vector>
+#include <list>
 
 namespace ymwm::window {
 
@@ -10,12 +10,11 @@ namespace ymwm::window {
     inline GroupManager(Environment* env)
         : m_env(env)
         , m_active_manager(0ul) {
-      m_managers.reserve(4);
       m_managers.emplace_back(m_env);
     }
 
     inline Manager<Environment>& manager() noexcept {
-      return m_managers.at(m_active_manager);
+      return *std::next(m_managers.begin(), m_active_manager);
     }
 
     inline void add() noexcept {
@@ -79,6 +78,6 @@ namespace ymwm::window {
 
     Environment* const m_env;
     std::size_t m_active_manager;
-    std::vector<Manager<Environment>> m_managers;
+    std::list<Manager<Environment>> m_managers;
   };
 } // namespace ymwm::window

--- a/src/window/Manager.h
+++ b/src/window/Manager.h
@@ -28,8 +28,7 @@ namespace ymwm::window {
                                     this,
                                     config::windows::focused_border_width,
                                     config::windows::focused_border_color))
-        , m_layout_manager(m_windows, env)
-        , m_active(true) {
+        , m_layout_manager(m_windows, env) {
       m_windows.reserve(5);
 
       layout().update(layouts::Centered{});
@@ -137,7 +136,6 @@ namespace ymwm::window {
     inline void activate() noexcept {
       layout().update();
       focus().update();
-      m_active = true;
     }
 
     inline void deactivate() noexcept {
@@ -145,11 +143,7 @@ namespace ymwm::window {
         w.x = 0 - w.w * 2;
         m_env->move_and_resize(w);
       }
-
-      m_active = false;
     }
-
-    inline bool active() const noexcept { return m_active; }
 
     inline FocusManager<Environment>& focus() noexcept {
       return m_focus_manager;
@@ -165,6 +159,5 @@ namespace ymwm::window {
     layouts::Layout m_layout;
     FocusManager<Environment> m_focus_manager;
     LayoutManager<Environment> m_layout_manager;
-    bool m_active;
   };
 } // namespace ymwm::window

--- a/src/window/Manager.h
+++ b/src/window/Manager.h
@@ -28,7 +28,8 @@ namespace ymwm::window {
                                     this,
                                     config::windows::focused_border_width,
                                     config::windows::focused_border_color))
-        , m_layout_manager(m_windows, env) {
+        , m_layout_manager(m_windows, env)
+        , m_active(true) {
       m_windows.reserve(5);
 
       layout().update(layouts::Centered{});
@@ -136,6 +137,7 @@ namespace ymwm::window {
     inline void activate() noexcept {
       layout().update();
       focus().update();
+      m_active = true;
     }
 
     inline void deactivate() noexcept {
@@ -143,7 +145,11 @@ namespace ymwm::window {
         w.x = 0 - w.w * 2;
         m_env->move_and_resize(w);
       }
+
+      m_active = false;
     }
+
+    inline bool active() const noexcept { return m_active; }
 
     inline FocusManager<Environment>& focus() noexcept {
       return m_focus_manager;
@@ -159,5 +165,6 @@ namespace ymwm::window {
     layouts::Layout m_layout;
     FocusManager<Environment> m_focus_manager;
     LayoutManager<Environment> m_layout_manager;
+    bool m_active;
   };
 } // namespace ymwm::window

--- a/src/window/Manager.h
+++ b/src/window/Manager.h
@@ -153,6 +153,13 @@ namespace ymwm::window {
       return m_layout_manager;
     }
 
+    ~Manager() noexcept {
+      for (const auto& w : m_windows) {
+        // Send `close` event to windows left in group.
+        m_env->close_window(w);
+      }
+    }
+
   private:
     std::vector<Window> m_windows;
     Environment* const m_env;

--- a/tests/window/WindowManagerTest.cpp
+++ b/tests/window/WindowManagerTest.cpp
@@ -266,6 +266,10 @@ TEST(TestWindowManager, CloseFocusedWindow) {
   EXPECT_CALL(tenv, close_window).WillOnce(testing::SaveArg<0>(&passed_window));
   m.close_focused_window();
 
+  // Expect close_window call for last window in Manager,
+  // as Manager sends `close` to windows left in Manager.
+  EXPECT_CALL(tenv, close_window);
+
   ASSERT_TRUE(m.focus().window());
   ASSERT_THAT(m.windows(),
               testing::ElementsAre(ymwm::window::Window{


### PR DESCRIPTION
When user removes all windows in Group it is reasonable to remove that same Group as well, thus not leaving behind empty Groups, which can stack up quickly, disorienting the user.
In case the Group is to be removed, having some windows inside, the Environment::close_window method will be called for each one before Group removal.
Any last Group is considered to be non-removable.