### PR TITLE
Move windows between groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.39.0 LANGUAGES CXX)
+project(WindowManager VERSION 0.40.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/Command.h
+++ b/src/environment/Command.h
@@ -24,7 +24,9 @@ namespace ymwm::environment::commands {
   DEFINE_COMMAND(FocusNextWindow)
   DEFINE_COMMAND(FocusPrevWindow)
   DEFINE_COMMAND(MoveFocusedWindowForward)
+  DEFINE_COMMAND(MoveFocusedWindowToNextGroup)
   DEFINE_COMMAND(MoveFocusedWindowBackward)
+  DEFINE_COMMAND(MoveFocusedWindowToPreviousGroup)
   DEFINE_COMMAND(ChangeLayout)
   DEFINE_COMMAND_WITH_PARAMS_1(SetLayout, std::string_view layout);
   DEFINE_COMMAND_WITH_PARAMS_1(IncreaseMainWindowRatio, int diff{ 10 });
@@ -50,7 +52,9 @@ namespace ymwm::environment::commands {
                                FocusNextWindow,
                                FocusPrevWindow,
                                MoveFocusedWindowForward,
+                               MoveFocusedWindowToNextGroup,
                                MoveFocusedWindowBackward,
+                               MoveFocusedWindowToPreviousGroup,
                                ChangeLayout,
                                SetLayout,
                                IncreaseMainWindowRatio,

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -50,9 +50,47 @@ namespace ymwm::environment::commands {
     e.manager().move_focused_window_forward();
   }
 
+  void MoveFocusedWindowToNextGroup::execute(Environment& e,
+                                             const events::Event&) const {
+    if (e.group().one_manager_present()) {
+      return;
+    }
+
+    auto w = e.group().manager().focus().window();
+    if (not w) {
+      return;
+    }
+
+    auto window_copy = window::Window{ w->get() };
+
+    e.group().manager().remove_window(w->get().id);
+
+    e.group().next();
+    e.group().manager().add_window(window_copy);
+  }
+
   void MoveFocusedWindowBackward::execute(Environment& e,
                                           const events::Event&) const {
     e.manager().move_focused_window_backward();
+  }
+
+  void MoveFocusedWindowToPreviousGroup::execute(Environment& e,
+                                                 const events::Event&) const {
+    if (e.group().one_manager_present()) {
+      return;
+    }
+
+    auto w = e.group().manager().focus().window();
+    if (not w) {
+      return;
+    }
+
+    auto window_copy = window::Window{ w->get() };
+
+    e.group().manager().remove_window(w->get().id);
+
+    e.group().prev();
+    e.group().manager().add_window(window_copy);
   }
 
   void ChangeLayout::execute(Environment& e, const events::Event&) const {

--- a/src/events/Map.cpp
+++ b/src/events/Map.cpp
@@ -194,9 +194,23 @@ namespace ymwm::events {
 
     bindings.emplace(
         ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::Period,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Shift },
+        ymwm::environment::commands::MoveFocusedWindowToNextGroup{});
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
             .code = ymwm::events::AbstractKeyCode::Comma,
             .mask = ymwm::events::AbstractKeyMask::Alt },
         ymwm::environment::commands::MoveToPrevGroup{});
+
+    bindings.emplace(
+        ymwm::events::AbstractKeyPress{
+            .code = ymwm::events::AbstractKeyCode::Comma,
+            .mask = ymwm::events::AbstractKeyMask::Alt |
+                    ymwm::events::AbstractKeyMask::Shift },
+        ymwm::environment::commands::MoveFocusedWindowToPreviousGroup{});
 
     bindings.emplace(
         ymwm::events::AbstractKeyPress{

--- a/src/window/GroupManager.h
+++ b/src/window/GroupManager.h
@@ -83,15 +83,15 @@ namespace ymwm::window {
 
     inline std::size_t active() const noexcept { return m_active_manager; }
 
+    inline bool one_manager_present() const noexcept {
+      return 1ul == m_managers.size();
+    }
+
     inline ~GroupManager() = default;
 
   private:
     inline bool valid_index(std::size_t manager_index) noexcept {
       return manager_index < m_managers.size();
-    }
-
-    inline bool one_manager_present() const noexcept {
-      return 1ul == m_managers.size();
     }
 
     inline bool is_first_active() const noexcept {


### PR DESCRIPTION
It is useful sometimes to move window from one group to another. E.g. some logs are running in terminal of Group 1, but you need that window in Group 2, where you have your Browser with some web app. For this MoveFocusedWindowToNext/PreviousGroup commands are implemented.