### PR TITLE
Copy screenshot to clipboard after saving

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(WindowManager VERSION 0.41.3 LANGUAGES CXX)
+project(WindowManager VERSION 0.42.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/Environment.h
+++ b/src/environment/Environment.h
@@ -18,7 +18,7 @@ namespace ymwm::environment {
     Environment(const events::Map& events_map);
     ~Environment();
 
-    events::Event event() const noexcept;
+    events::Event event() noexcept;
     void execute(const commands::Command& cmd,
                  [[maybe_unused]] const events::Event& event);
     bool exit_requested() const noexcept;

--- a/src/environment/ScreenshotHandler.h
+++ b/src/environment/ScreenshotHandler.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <array>
+#include <cstdint>
+#include <filesystem>
 #include <optional>
+#include <vector>
 
 namespace ymwm::environment {
   struct Environment;
@@ -12,9 +15,17 @@ namespace ymwm::environment {
 
     ScreenshotHandler& add(const std::array<int, 2ul>& coords) noexcept;
     void make(Environment& env) noexcept;
+    bool has_screenshot() const noexcept;
+
+    const std::vector<std::uint32_t>& screenshot() const noexcept;
+    const std::filesystem::path& screenshot_path() const noexcept;
+
+    void reset() noexcept;
 
   private:
     std::optional<std::array<int, 2ul>> m_start_coords;
     std::optional<std::array<int, 2ul>> m_end_coords;
+    std::vector<std::uint32_t> m_screenshot;
+    std::filesystem::path m_screenshot_path;
   };
 } // namespace ymwm::environment

--- a/src/environment/x11/AtomID.h
+++ b/src/environment/x11/AtomID.h
@@ -1,5 +1,13 @@
 #pragma once
 
 namespace ymwm::environment {
-  enum AtomID { NetWMName, Utf8String };
+  enum AtomID {
+    NetWMName,
+    Utf8String,
+    Clipboard,
+    Targets,
+    ScreenshotImage,
+    ScreenshotPathsList,
+    ScreenshotPath
+  };
 }

--- a/src/environment/x11/Environment.cpp
+++ b/src/environment/x11/Environment.cpp
@@ -8,7 +8,8 @@ namespace ymwm::environment {
   int handle_x_error(Display* display, XErrorEvent* error);
   int handle_x_io_error(Display* display);
   XColor xcolor_from_color(const common::Color& c) noexcept;
-  ymwm::events::Event x11_to_abstract_event(XEvent& event, Handlers& handlers);
+  ymwm::events::Event
+  x11_to_abstract_event(XEvent& event, Handlers& handlers, Environment& e);
   bool register_colors(const std::array<common::Color, 3ul>& colors,
                        Handlers& handlers);
 } // namespace ymwm::environment
@@ -73,11 +74,11 @@ namespace ymwm::environment {
         m_handlers->display, AnyButton, AnyModifier, m_handlers->root_window);
   }
 
-  events::Event Environment::event() const noexcept {
+  events::Event Environment::event() noexcept {
     XEvent event;
     XSync(m_handlers->display, false);
     XNextEvent(m_handlers->display, &event);
-    return x11_to_abstract_event(event, *m_handlers);
+    return x11_to_abstract_event(event, *m_handlers, *this);
   }
 
   Handlers& Environment::handlers() noexcept { return *m_handlers; }

--- a/src/environment/x11/Handlers.cpp
+++ b/src/environment/x11/Handlers.cpp
@@ -22,6 +22,13 @@ namespace ymwm::environment {
     colors.reserve(1);
     atoms.at(AtomID::NetWMName) = XInternAtom(display, "_NET_WM_NAME", False);
     atoms.at(AtomID::Utf8String) = XInternAtom(display, "UTF8_STRING", False);
+    atoms.at(AtomID::Clipboard) = XInternAtom(display, "CLIPBOARD", False);
+    atoms.at(AtomID::Targets) = XInternAtom(display, "TARGETS", False);
+    atoms.at(AtomID::ScreenshotImage) =
+        XInternAtom(display, "image/png", False);
+    atoms.at(AtomID::ScreenshotPathsList) =
+        XInternAtom(display, "text/uri-list", False);
+    atoms.at(AtomID::ScreenshotPath) = XInternAtom(display, "text/uri", False);
     current_layout = 0;
     max_layouts = get_number_of_layouts();
     if (not ymwm::config::misc::background_image_path.empty() and

--- a/src/environment/x11/Handlers.h
+++ b/src/environment/x11/Handlers.h
@@ -17,7 +17,7 @@ namespace ymwm::environment {
     Colormap colormap;
     std::unique_ptr<BackgroundImageHandler> background_image;
     std::unordered_map<common::Color, XColor, common::ColorHash> colors;
-    std::array<Atom, 2ul> atoms;
+    std::array<Atom, 7ul> atoms;
     int current_layout;
     int max_layouts;
 


### PR DESCRIPTION
It is handy to paste fresh-created screenshot with Ctrl+V right into e.g. telegram chat. This PR provides handling X11 clipboard, inserting screenshot into window property.