### PR TITLE
Remove group removal after last window being deleted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(YMWM VERSION 2.1.0 LANGUAGES CXX)
+project(YMWM VERSION 2.1.1 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -160,9 +160,6 @@ namespace ymwm::environment::commands {
   void RemoveWindow::execute(Environment& e, const events::Event& event) const {
     if (const auto* ev = std::get_if<events::WindowRemoved>(&event)) {
       e.manager().remove_window(ev->wid);
-      if (e.manager().windows().empty()) {
-        e.group().remove(e.group().active());
-      }
     }
   }
 


### PR DESCRIPTION
In case of opening clients, that tend to create one window as initial, close it and then open the new one as main (e.g. slack) the group would be removed after the initial window removal, resulting in moving the main window to the last created group. That behavior led to inadequate user experience, where user had to move window into new group manually afterwards.
Thus, it is better to have groups removed manually on demand.