### PR TITLE
Enhance windows focus management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(YMWM VERSION 2.1.1 LANGUAGES CXX)
+project(YMWM VERSION 2.2.0 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -53,6 +53,11 @@ namespace ymwm::config {
       return;
     }
 
+    if (auto autofocus_on_mousehover = windows["autofocus_on_mousehover"]) {
+      ymwm::config::windows::autofocus_on_mousehover =
+          autofocus_on_mousehover.as<bool>();
+    }
+
     if (auto focused = windows["focused"]) {
       if (auto border = focused["border"]) {
 
@@ -320,6 +325,7 @@ namespace ymwm::config {
 
     // Create the "windows" node
     YAML::Node windows;
+    windows["autofocus_on_mousehover"] = autofocus_on_mousehover;
     windows["regular"]["border"]["width"] = regular_border_width;
     windows["regular"]["border"]["color"] = regular_border_color;
 

--- a/src/config/Window.h
+++ b/src/config/Window.h
@@ -7,4 +7,5 @@ namespace ymwm::config::windows {
   inline ymwm::common::Color focused_border_color{ 0x0, 0xff, 0x0 };
   constinit inline int regular_border_width{ 2 };
   constinit inline int focused_border_width{ 5 };
+  constinit inline bool autofocus_on_mousehover{ true };
 } // namespace ymwm::config::windows

--- a/src/environment/x11/AtomID.h
+++ b/src/environment/x11/AtomID.h
@@ -8,6 +8,7 @@ namespace ymwm::environment {
     Targets,
     ScreenshotImage,
     ScreenshotPathsList,
-    ScreenshotPath
+    ScreenshotPath,
+    NetActiveWindow
   };
 }

--- a/src/environment/x11/Environment.cpp
+++ b/src/environment/x11/Environment.cpp
@@ -3,6 +3,7 @@
 #include "Handlers.h"
 #include "XClientKeyGrabber.h"
 #include "common/Color.h"
+#include "environment/x11/AtomID.h"
 
 namespace ymwm::environment {
   int handle_x_error(Display* display, XErrorEvent* error);
@@ -110,6 +111,14 @@ namespace ymwm::environment {
   void Environment::focus_window(const window::Window& w) noexcept {
     XRaiseWindow(m_handlers->display, w.id);
     XSetInputFocus(m_handlers->display, w.id, RevertToPointerRoot, CurrentTime);
+    XChangeProperty(m_handlers->display,
+                    m_handlers->root_window,
+                    m_handlers->atoms.at(AtomID::NetActiveWindow),
+                    XA_WINDOW,
+                    32,
+                    PropModeReplace,
+                    (unsigned char*)&(w.id),
+                    1);
     x_send_expose_event(*m_handlers, w.id);
   }
 
@@ -118,6 +127,9 @@ namespace ymwm::environment {
                    m_handlers->root_window,
                    RevertToPointerRoot,
                    CurrentTime);
+    XDeleteProperty(m_handlers->display,
+                    m_handlers->root_window,
+                    m_handlers->atoms.at(AtomID::NetActiveWindow));
   }
 
   void Environment::change_border_color(const window::Window& w) noexcept {

--- a/src/environment/x11/Handlers.cpp
+++ b/src/environment/x11/Handlers.cpp
@@ -21,6 +21,8 @@ namespace ymwm::environment {
         display, root_window, DefaultVisual(display, screen), AllocNone);
     colors.reserve(1);
     atoms.at(AtomID::NetWMName) = XInternAtom(display, "_NET_WM_NAME", False);
+    atoms.at(AtomID::NetActiveWindow) =
+        XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
     atoms.at(AtomID::Utf8String) = XInternAtom(display, "UTF8_STRING", False);
     atoms.at(AtomID::Clipboard) = XInternAtom(display, "CLIPBOARD", False);
     atoms.at(AtomID::Targets) = XInternAtom(display, "TARGETS", False);

--- a/src/environment/x11/Handlers.h
+++ b/src/environment/x11/Handlers.h
@@ -17,7 +17,7 @@ namespace ymwm::environment {
     Colormap colormap;
     std::unique_ptr<BackgroundImageHandler> background_image;
     std::unordered_map<common::Color, XColor, common::ColorHash> colors;
-    std::array<Atom, 7ul> atoms;
+    std::array<Atom, 8ul> atoms;
     int current_layout;
     int max_layouts;
 

--- a/src/environment/x11/X11ToAbstractEvent.cpp
+++ b/src/environment/x11/X11ToAbstractEvent.cpp
@@ -82,7 +82,8 @@ namespace ymwm::environment {
   ymwm::events::Event enter_notify(XEvent& event, Handlers& handlers) {
 
     if (NotifyNormal == event.xcrossing.mode and
-        NotifyInferior != event.xcrossing.detail) {
+        NotifyInferior != event.xcrossing.detail and
+        config::windows::autofocus_on_mousehover) {
       return events::MouseOverWindow{ .wid = event.xcrossing.window };
     }
 

--- a/src/environment/x11/X11ToAbstractEvent.cpp
+++ b/src/environment/x11/X11ToAbstractEvent.cpp
@@ -19,6 +19,8 @@ namespace ymwm::environment {
   ymwm::events::Event destroy_notify(XEvent& event, Handlers& handlers);
   ymwm::events::Event button_press(XEvent& event, Handlers& handlers);
   ymwm::events::Event
+  focus_in(XEvent& event, Handlers& handlers, Environment& e);
+  ymwm::events::Event
   selection_request(XEvent& event, Handlers& handlers, Environment& e);
   ymwm::events::Event
   selection_clear(XEvent& event, Handlers& handlers, Environment& e);
@@ -47,6 +49,8 @@ namespace ymwm::environment {
       return selection_request(event, handlers, e);
     case SelectionClear:
       return selection_clear(event, handlers, e);
+    case FocusIn:
+      return focus_in(event, handlers, e);
     }
 
     return ymwm::events::AbstractUnknownEvent{};
@@ -210,6 +214,15 @@ namespace ymwm::environment {
   ymwm::events::Event
   selection_clear(XEvent& event, Handlers& handlers, Environment& e) {
     e.screenshot().reset();
+    return events::AbstractUnknownEvent{};
+  }
+
+  ymwm::events::Event
+  focus_in(XEvent& event, Handlers& handlers, Environment& e) {
+    const auto current_focused_window = e.group().manager().focus().window();
+    if (event.xfocus.window != current_focused_window->get().w) {
+      e.focus_window(current_focused_window->get());
+    }
     return events::AbstractUnknownEvent{};
   }
 } // namespace ymwm::environment

--- a/tests/config/ParserTest.cpp
+++ b/tests/config/ParserTest.cpp
@@ -225,6 +225,7 @@ TEST(TestConfig, AllValidConfig) {
   EXPECT_EQ("us,ru,ua", ymwm::config::misc::language_layout);
   EXPECT_EQ("/tmp/some.png", ymwm::config::misc::background_image_path);
   EXPECT_EQ("/home/user/Pictures", ymwm::config::misc::screenshots_folder);
+  EXPECT_FALSE(ymwm::config::windows::autofocus_on_mousehover);
   ymwm::events::Map events_map;
   EXPECT_NO_THROW(events_map = parser.event_map());
   auto event1 = ymwm::events::AbstractKeyPress{
@@ -322,6 +323,7 @@ TEST(TestConfig, GenerateConfigToFile) {
   ymwm::config::misc::language_layout = "ru,fr,de";
   ymwm::config::misc::background_image_path = "/tmp/someimg.png";
   ymwm::config::misc::screenshots_folder = "/home/user/folder";
+  ymwm::config::windows::autofocus_on_mousehover = false;
 
   const std::filesystem::path test_config_path =
       std::filesystem::temp_directory_path() / "test-config.yaml";
@@ -358,6 +360,7 @@ TEST(TestConfig, GenerateConfigToFile) {
   EXPECT_EQ("ru,fr,de", ymwm::config::misc::language_layout);
   EXPECT_EQ("/tmp/someimg.png", ymwm::config::misc::background_image_path);
   EXPECT_EQ("/home/user/folder", ymwm::config::misc::screenshots_folder);
+  EXPECT_FALSE(ymwm::config::windows::autofocus_on_mousehover);
 
   ASSERT_EQ(parsed_event_map.size(), default_event_map.size());
 

--- a/tests/config/all-config.yaml
+++ b/tests/config/all-config.yaml
@@ -22,6 +22,7 @@ layouts:
     window-width-ratio: 90
 
 windows:
+  autofocus_on_mousehover: false
   focused:
     border:
       width: 10


### PR DESCRIPTION
Current version of window manager has a bit chaotic focus management, meaning that focus is not only assigned by user manually, but also can be switched by windows demanding that focus. In this case user may appear random stop of typing in terminal while firefox browser opens or zoom meeting has popping up windows like chat or notifications.
To fix such behavior the control was added for FocusIn events (when window notifies it achieved focus), preventing from focusing window which is not being assigned as focused by FocusManager. 
Additionally, when mouse cursor is right on top of the window not in focus it will send EnterNotify event even though cursor appeared without mouse move, resulting in accidental switch of focus as well. This PR adds `autofocus_on_mousehover` flag into windows settings, if user wish not to experience such behavior.  