### PR TITLE
Fix crash on window removal in non-first group

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(YMWM VERSION 2.2.0 LANGUAGES CXX)
+project(YMWM VERSION 2.2.1 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/x11/X11ToAbstractEvent.cpp
+++ b/src/environment/x11/X11ToAbstractEvent.cpp
@@ -221,7 +221,8 @@ namespace ymwm::environment {
   ymwm::events::Event
   focus_in(XEvent& event, Handlers& handlers, Environment& e) {
     const auto current_focused_window = e.group().manager().focus().window();
-    if (event.xfocus.window != current_focused_window->get().w) {
+    if (current_focused_window.has_value() and
+        event.xfocus.window != current_focused_window->get().w) {
       e.focus_window(current_focused_window->get());
     }
     return events::AbstractUnknownEvent{};


### PR DESCRIPTION
After removing last window in non-first group there was a crash caused by absence of check, whether the current group still has focused window at all. 
Added check for focused window presence.