### PR TITLE
Move window in circular mode between groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(YMWM VERSION 2.5.0 LANGUAGES CXX)
+project(YMWM VERSION 2.5.1 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/x11/Commands.cpp
+++ b/src/environment/x11/Commands.cpp
@@ -63,11 +63,7 @@ namespace ymwm::environment::commands {
 
     e.group().manager().remove_window(w->get().id);
 
-    if (e.group().is_last_active()) {
-      e.group().add();
-    } else {
-      e.group().next();
-    }
+    e.group().next();
 
     e.group().manager().add_window(window_copy);
   }


### PR DESCRIPTION
Previously window moving to the next group would force to create new group, if group was the last in list. This approach proved to be failing in long term.
It is better to have explicit and separated functionality of window move and group management.