### PR TITLE
Fix removal of child windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(YMWM VERSION 2.6.0 LANGUAGES CXX)
+project(YMWM VERSION 2.6.1 LANGUAGES CXX)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/environment/x11/AtomID.h
+++ b/src/environment/x11/AtomID.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 namespace ymwm::environment {
   enum AtomID {
@@ -9,6 +10,10 @@ namespace ymwm::environment {
     ScreenshotImage,
     ScreenshotPathsList,
     ScreenshotPath,
-    NetActiveWindow
+    NetActiveWindow,
+    DeleteWindow,
+    Protocols
   };
-}
+
+  static constexpr inline std::size_t AtomIDSize{ 10 };
+} // namespace ymwm::environment

--- a/src/environment/x11/Environment.cpp
+++ b/src/environment/x11/Environment.cpp
@@ -5,6 +5,8 @@
 #include "common/Color.h"
 #include "environment/x11/AtomID.h"
 
+#include <memory>
+
 namespace ymwm::environment {
   int handle_x_error(Display* display, XErrorEvent* error);
   int handle_x_io_error(Display* display);
@@ -14,6 +16,8 @@ namespace ymwm::environment {
   bool register_colors(const std::array<common::Color, 3ul>& colors,
                        Handlers& handlers);
   void x_send_expose_event(Handlers& handlers, ID window_id) noexcept;
+  bool x_send_delete_window_event(Handlers& handlers, ID window_id) noexcept;
+  bool x_window_is_child(Handlers& handlers, ID window_id) noexcept;
 } // namespace ymwm::environment
 
 namespace ymwm::environment {
@@ -142,8 +146,11 @@ namespace ymwm::environment {
 
   void Environment::close_window(const window::Window& w) noexcept {
     auto id = w.id;
-    // XUnmapWindow(m_handlers->display, id);
-    // XDestroyWindow(m_handlers->display, id);
+
+    if (x_send_delete_window_event(*m_handlers, id)) {
+      return;
+    }
+
     XKillClient(m_handlers->display, id);
   }
 

--- a/src/environment/x11/Handlers.cpp
+++ b/src/environment/x11/Handlers.cpp
@@ -6,6 +6,7 @@
 #include "environment/x11/XkbComponentNamesRecWrapper.h"
 #include "environment/x11/XkbRF_VarDefsRecWrapper.h"
 
+#include <X11/Xlib.h>
 #include <algorithm>
 
 namespace ymwm::environment {
@@ -31,6 +32,9 @@ namespace ymwm::environment {
     atoms.at(AtomID::ScreenshotPathsList) =
         XInternAtom(display, "text/uri-list", False);
     atoms.at(AtomID::ScreenshotPath) = XInternAtom(display, "text/uri", False);
+    atoms.at(AtomID::DeleteWindow) =
+        XInternAtom(display, "WM_DELETE_WINDOW", False);
+    atoms.at(AtomID::Protocols) = XInternAtom(display, "WM_PROTOCOLS", False);
     current_layout = 0;
     max_layouts = get_number_of_layouts();
     if (not ymwm::config::misc::background_image_path.empty() and

--- a/src/environment/x11/Handlers.h
+++ b/src/environment/x11/Handlers.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "BackgroundImageHandler.h"
 #include "common/Color.h"
+#include "environment/x11/AtomID.h"
 
 #include <array>
 #include <cstring>
@@ -17,7 +18,7 @@ namespace ymwm::environment {
     Colormap colormap;
     std::unique_ptr<BackgroundImageHandler> background_image;
     std::unordered_map<common::Color, XColor, common::ColorHash> colors;
-    std::array<Atom, 8ul> atoms;
+    std::array<Atom, AtomIDSize> atoms;
     int current_layout;
     int max_layouts;
 


### PR DESCRIPTION
Removing window by calling XKillClient on window would cause panic in client itself, e.g. killing all other windows (parent or child) related to that one, e.g. Chrome new sessions.
With this PR YMWM verifies that client supports Destroy Window event handling and sends the event. If client doesn't support such thing - XKillClient is called as fallback. 